### PR TITLE
Add template linting

### DIFF
--- a/.template-lintrc.js
+++ b/.template-lintrc.js
@@ -1,0 +1,9 @@
+/* jshint node:true */
+'use strict';
+
+module.exports = {
+    extends: 'recommended',
+    rules: {
+        'block-indentation': 4
+    }
+};

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "ember-cli-release": "0.2.8",
     "ember-cli-sass": "5.3.1",
     "ember-cli-sri": "^2.1.0",
+    "ember-cli-template-lint": "0.4.11",
     "ember-cli-uglify": "^1.2.0",
     "ember-data": "^2.5.0",
     "ember-data-url-templates": "0.1.1",


### PR DESCRIPTION
Will help keep templates clean, used in `ember-osf`.