### PR TITLE
[hold][WIP] add tags widget to preprint form

### DIFF
--- a/app/templates/components/preprint-form-basics.hbs
+++ b/app/templates/components/preprint-form-basics.hbs
@@ -9,7 +9,7 @@
     </label>
     <label>
         Tags:
-        {{input class="form-control" value=tags}}
+        {{tags-widget}}
     </label>
 </div>
 <div class="col-md-6">

--- a/bower.json
+++ b/bower.json
@@ -1,17 +1,18 @@
 {
-  "name": "preprint-service",
-  "dependencies": {
-    "ember": "~2.7.0",
-    "ember-cli-shims": "0.1.1",
-    "ember-qunit-notifications": "0.1.0",
-    "osf-style": "https://github.com/CenterForOpenScience/osf-style.git#5dcf5997ad2808ffc7c8564f94cde102bf7a4a96",
-    "font-awesome": "~4.6.3",
-    "jquery": "^2.2.4",
-    "pretender": "~1.1.0",
-    "Faker": "~3.1.0",
-    "bootstrap-treeview": "^1.2.0",
-    "dropzone": "^4.3.0",
-    "bootstrap-sass": "^3.3.6",
-    "toastr": "^2.1.2"
-  }
+    "name": "preprint-service",
+    "dependencies": {
+        "ember": "~2.7.0",
+        "ember-cli-shims": "0.1.1",
+        "ember-qunit-notifications": "0.1.0",
+        "osf-style": "https://github.com/CenterForOpenScience/osf-style.git#5dcf5997ad2808ffc7c8564f94cde102bf7a4a96",
+        "font-awesome": "~4.6.3",
+        "jquery": "^2.2.4",
+        "pretender": "~1.1.0",
+        "Faker": "~3.1.0",
+        "bootstrap-treeview": "^1.2.0",
+        "dropzone": "^4.3.0",
+        "bootstrap-sass": "^3.3.6",
+        "toastr": "^2.1.2",
+        "jquery.tagsinput": "^1.3.6"
+    }
 }

--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -77,6 +77,8 @@ module.exports = function(defaults) {
         development: 'bower_components/bootstrap-treeview/src/js/bootstrap-treeview.js',
         production: 'bower_components/bootstrap-treeview/dist/js/bootstrap-treeview.min.js'
     });
+    app.import('bower_components/jquery.tagsinput/src/jquery.tagsinput.js');
+    app.import('bower_components/jquery.tagsinput/src/jquery.tagsinput.css');
 
     return app.toTree();
 };

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "ember-cli-test-loader": "^1.1.0",
     "ember-cli-uglify": "^1.2.0",
     "ember-collapsible-panel": "1.0.0",
+    "ember-cp-validations": "2.9.3",
     "ember-data": "^2.7.0",
     "ember-export-application-global": "^1.0.5",
     "ember-font-awesome": "2.1.1",


### PR DESCRIPTION
Add ember-osf's tags widget into the preprint form. This is a front-end only feature.