### PR TITLE
Allow conversion of node into preprint

### DIFF
--- a/app/adapters/preprint.js
+++ b/app/adapters/preprint.js
@@ -1,4 +1,11 @@
 import OsfAdapter from 'ember-osf/adapters/osf-adapter';
 
+// TODO: This is an OSF apiv2 endpoints, and should be moved to the ember-osf addon.
 export default OsfAdapter.extend({
+    urlForCreateRecord(modelName, snapshot) {
+        // Preprints are posted to /preprints/<guid_of_source_node>/
+        // Constructing the appropriate URL thus depends on passing an extra ID param when creating the record
+        let url = this._super(...arguments);
+        return `${url}/${snapshot.id}/`;
+    }
 });

--- a/app/serializers/preprint.js
+++ b/app/serializers/preprint.js
@@ -1,4 +1,19 @@
 import OsfSerializer from 'ember-osf/serializers/osf-serializer';
 
 export default OsfSerializer.extend({
+    serialize(snapshot) {
+        // Normal OSF serializer strips out relationships. We need to add back primaryFile for this endpoint
+        let res = this._super(...arguments);
+        res.data.relationships = {
+            // Not sure what the name of this key comes from, but it's required.
+            preprint_file: {
+                data: {
+                    id: snapshot.belongsTo('primaryFile', { id: true }),
+                    type: 'primary_file'
+                }
+            }
+        };
+        return res;
+    }
+
 });


### PR DESCRIPTION
## Purpose
Allow a node to be converted into a preprint.

## Summary of changes
Modify adapter and serializer to support unique requirements for this endpoint:
1. Custom URLS
2. Custom relationship payload, including what seems to be a special key not matching a field name

## Future
Assess whether this allows editing of an existing preprint. (editing primary file or subjects, etc)

## Sample usage
See the ticket for notes about the workflow from the API standpoint. Below is a deliberately crude code snippet I used in a local demo route, to test whether this worked. Key requirements are an existing file, a valid subject, and explicitly passing the `id` parameter = the GUID of the originating node that will become a preprint.

(the latter is used for the serializer)

In the route:
```handlebars
<button {{action 'registerPreprint' model.node model.file subjects}} class="btn btn-success">Register me</button>

```

In the component:
```javascript
    ...
    model() {
        // Get two things from localhost OSF, hardcoding some IDs as needed.
        return Ember.RSVP.hash({
            node: this.store.findRecord('node', 'q2hnc'),
            file: this.store.findRecord('file', '57aa4402c4f5fb25b271a278')
        });
    },
    actions: {
        registerPreprint(node, primaryFile, subjects) {
            subjects = subjects || ['57a9522bc4f5fba37fe15f30'];
            let newPreprint = this.store.createRecord('preprint', {
                id: node.id,
                subjects: subjects,
                primaryFile: primaryFile
            });

            newPreprint.save()
                .then(() => console.log('Record created!'))
                .catch((err)=> console.log('Something happened, yo: ', err));
        }
    }
...
```

## Ticket
https://openscience.atlassian.net/browse/PREP-101