### PR TITLE
Update payload to match new parser for file relationship

### DIFF
--- a/app/serializers/preprint.js
+++ b/app/serializers/preprint.js
@@ -5,11 +5,10 @@ export default OsfSerializer.extend({
         // Normal OSF serializer strips out relationships. We need to add back primaryFile for this endpoint
         let res = this._super(...arguments);
         res.data.relationships = {
-            // Not sure what the name of this key comes from, but it's required.
-            preprint_file: {
+            primary_file: {
                 data: {
                     id: snapshot.belongsTo('primaryFile', { id: true }),
-                    type: 'primary_file'
+                    type: 'file'
                 }
             }
         };


### PR DESCRIPTION
Fixes bug pointed out by [comment in #21](https://github.com/CenterForOpenScience/ember-preprints/pull/21/files#diff-ea08ccd8a33b794610a037162feb43d5R8) that relationship field name was odd. Relationship field name should now be passed to match name of primary_file in preprint serializer (was before relying on the type field).

**Note!** This PR relies on merging https://github.com/CenterForOpenScience/osf.io/pull/6141 which fixes the preprint relationship parser to look at the appropriate keys instead of relying on the type passed in with data
