### PR TITLE
[blockers] Add option to create child components, part of [PREP-92]

### DIFF
--- a/app/components/preprint-form-section.js
+++ b/app/components/preprint-form-section.js
@@ -9,6 +9,12 @@ export default CpPanelComponent.extend({
     _setup: Ember.on('init', Ember.observer('open', function() {
         this.set('panelState.boundOpenState', this.get('open'));
     })),
+    /* Manual animation
+     * Can be omitted if using {{cp-panel-body}} instead of {{preprint-form-body}} because
+     * cp-panel-body uses liquid-if for animation. preprint-form-body purposely avoids liquid-if
+     * because liquid-if will cause elements to be removed from DOM. This is can cause some
+     * information to be lost (e.g. dropzone state).
+     */
     slideAnimation: Ember.observer('isOpen', function() {
         if (this.get('animate')) {
             // Allow liquid-fire to animate
@@ -32,6 +38,7 @@ export default CpPanelComponent.extend({
             $body.height('');
         }
     }),
+    // Called when panel is toggled
     handleToggle() {
         // Prevent closing all views
         if (!this.get('isOpen')) {

--- a/app/controllers/add-preprint.js
+++ b/app/controllers/add-preprint.js
@@ -2,7 +2,7 @@ import Ember from 'ember';
 import loadAll from 'ember-osf/utils/load-relationship';
 import NodeActionsMixin from 'ember-osf/mixins/node-actions';
 
-// Enum of available states
+// Enum of available upload states
 export const State = Object.freeze(new Ember.Object({
     START: 'start',
     NEW: 'new',
@@ -16,12 +16,14 @@ export default Ember.Controller.extend(NodeActionsMixin, {
     currentUser: Ember.inject.service(),
     fileManager: Ember.inject.service(),
 
+    // Upload variables
     _State: State,
     state: State.START,
     uploadState: State.START,
     uploadFile: null,
     resolve: null,
-    preprintNode: null,
+    model: null,         // Node to transform into preprint
+    shouldCreateChild: false,
     user: null,
     userNodes: Ember.A([]),
     dropzoneOptions: {
@@ -30,13 +32,16 @@ export default Ember.Controller.extend(NodeActionsMixin, {
     },
 
     _names: ['upload', 'basics', 'subjects', 'authors', 'submit'].map(str => str.capitalize()),
-    valid: new Ember.Object(),
     init() {
         this._super(...arguments);
         if (this.get('session.isAuthenticated')) {
             this._setCurrentUser();
         }
     },
+
+    /*
+     * Retrieving userNodes
+     */
     _setCurrentUser() {
         this.get('currentUser').load().then(user => this.set('user', user));
     },
@@ -52,7 +57,10 @@ export default Ember.Controller.extend(NodeActionsMixin, {
         this._refreshNodes();
     }),
 
-    filter: [{}, {}, {}],
+    /*
+     * Subjects section
+     */
+    filter: [{/* value: 'filterQuery' */}, {}, {}],
     filteredPath: Ember.computed('path', 'filter', 'filter.@each.value', function() {
         return this.get('path').slice(0, 2).map((path, i) => {
             if (path.children && this.get(`filter.${i + 1}.value`)) {
@@ -66,6 +74,7 @@ export default Ember.Controller.extend(NodeActionsMixin, {
         });
     }),
     sortedTaxonomies: Ember.computed('taxonomies', 'filter', 'filter.0.value', function() {
+        // Format of data that is expected in the hbs
         return [{
             name: 'a',
             children: [{
@@ -88,7 +97,16 @@ export default Ember.Controller.extend(NodeActionsMixin, {
         );
     }),
     path: [],
+    /*
+     * selected takes the format of: { taxonomy: { category: { subject: {}, subject2: {}}, category2: {}}}
+     * in other words, each key is the name of one of the taxonomies, and each value is an object
+     * containing child values.
+     */
     selected: new Ember.Object(),
+    /*
+     * sortedSelection takes the format of: [['taxonomy', 'category', 'subject'], ['taxonomy'...]]
+     * in other words, a 2D array
+     */
     sortedSelection: Ember.computed('selected', function() {
         const sorted = [];
         const selected = this.get('selected');
@@ -107,50 +125,56 @@ export default Ember.Controller.extend(NodeActionsMixin, {
     }),
 
     actions: {
-        verify(name, state) {
-            this.get('valid').set(name, state);
-        },
+        // Open next panel
         next(name) {
-            // Open next panel
             this.get('panelActions').open(this.get(`_names.${this.get('_names').indexOf(name) + 1}`));
         },
+        /*
+         * Upload section
+         */
         changeState(newState) {
             this.set('state', newState);
         },
         changeUploadState(newState) {
             this.set('uploadState', newState);
         },
-        createProject(resolve) {
-            const node = this.get('store').createRecord('node', {
+        createProject(nextAction) {
+            this.get('store').createRecord('node', {
                 title: this.get('nodeTitle'),
                 category: 'project',
                 public: true
-            });
-            node.save().then(() => {
-                this.set('preprintNode', node);
+            }).save().then(node => {
+                this.set('model', node);
                 this._refreshNodes();
-                this.send('startUpload', resolve);
+                this.send('startUpload', nextAction);
             });
         },
-        deleteProject(resolve) {
-            if (this.get('preprintNode')) {
-                this.get('preprintNode').destroyRecord().then(() => {
+        createChild(nextAction) {
+            // TODO: create child and set to model
+            this.get('toast').warning('Not implemented!');
+            this.send('startUpload', nextAction);
+        },
+        deleteProject(nextAction) {
+            if (this.get('model')) {
+                this.get('model').destroyRecord().then(() => {
                     this.get('toast').info('Project deleted');
                 });
-                this.set('preprintNode', null);
+                this.set('model', null);
                 // TODO: reset dropzone, since uploaded file has no project
             }
-            resolve();
+            nextAction();
         },
+        startUpload(nextAction) {
+            // TODO: retrieve and save fileid from uploaded file
+            this.set('_url', `${this.get('model.files').findBy('name', 'osfstorage').get('links.upload')}?kind=file&name=${this.get('uploadFile.name')}`);
+            this.get('resolve')();
+            this.get('toast').info('File will upload in the background.');
+            nextAction();
+        },
+        // Dropzone hooks
         preUpload(ignore, dropzone, file) {
             this.set('uploadFile', file);
             return new Ember.RSVP.Promise(resolve => this.set('resolve', resolve));
-        },
-        startUpload(resolve) {
-            this.set('_url', `${this.get('preprintNode.files').findBy('name', 'osfstorage').get('links.upload')}?kind=file&name=${this.get('uploadFile.name')}`);
-            this.get('resolve')();
-            this.get('toast').info('File will upload in the background.');
-            resolve();
         },
         buildUrl() {
             return this.get('_url');
@@ -158,6 +182,9 @@ export default Ember.Controller.extend(NodeActionsMixin, {
         success() {
             this.get('toast').info('File uploaded!');
         },
+        /*
+         * Subject section
+         */
         deleteSubject(key, array = key.split('.')) {
             this.set(key, null);
             // Delete key manually
@@ -190,7 +217,7 @@ export default Ember.Controller.extend(NodeActionsMixin, {
                 } else if (i === 3 || i === args.length && args.length === this.get('path').length &&
                     this.get('path').every((e, i) => e.name === args[i].name) &&
                     Object.keys(selected).length === 0) {
-                    // Deselecting a subject: if subject is last item in args,
+                    // Deselecting a subject: if subject is last item in args, path matches previous path,
                     // its children are showing, and no children are selected
                     this.send('deleteSubject', `selected.${prev}`, ['selected', ...arr.splice(0, i)]);
                     args.popObject();

--- a/app/templates/add-preprint.hbs
+++ b/app/templates/add-preprint.hbs
@@ -23,22 +23,24 @@
                                         <h1>Creating new project</h1>
                                         {{input class='form-control' value=nodeTitle}}
                                         <button class="btn btn-default" {{action 'deleteProject' (action 'changeUploadState' _State.START)}}>Back</button>
+                                        {{! TODO: check if dropzone has file before allowing user to continue }}
                                         <button class="btn btn-primary" {{action 'createProject' (action 'next' name)}}>Create</button>
 
                                     {{else if (eq currentUploadState _State.EXISTING)}}
-                                        {{preprint-form-project-select userNodes=userNodes selectedNode=preprintNode}}
+                                        {{preprint-form-project-select userNodes=userNodes selectedNode=model shouldCreateChild=shouldCreateChild}}
                                         <button class="btn btn-default" {{action 'changeUploadState' _State.START}}>Back</button>
-                                        <button class="btn btn-primary" disabled={{unless preprintNode true}} {{action 'startUpload' (action 'next' name)}}>Next</button>
-
+                                        {{! TODO: check if dropzone has file and model exists before allowing user to continue }}
+                                        <button class="btn btn-primary" disabled={{unless model true}} {{action (if shouldCreateChild 'createChild' 'startUpload') (action 'next' name)}}>Next</button>
                                     {{else}}
                                         {{log 'preprint-form-upload: bad uploadState'}}
                                     {{/if}}
                                 {{/liquid-bind}}
 
                             {{else if (eq currentState _State.EXISTING)}}
-                                {{preprint-form-project-select userNodes=userNodes fileSelect=true selectedNode=preprintNode}}
+                                {{preprint-form-project-select userNodes=userNodes fileSelect=true selectedNode=model shouldCreateChild=shouldCreateChild}}
                                 <button class="btn btn-default" {{action 'changeState' _State.START}}>Back</button>
-                                <button class="btn btn-primary" disabled={{unless preprintNode true}} {{action 'next' name}}>Next</button>
+                                {{! TODO: check if project and file are selected before allowing user to continue }}
+                                <button class="btn btn-primary" disabled={{unless model true}} {{action 'next' name}}>Next</button>
 
                             {{else}}
                                 {{log 'preprint-form-upload: bad state'}}

--- a/app/templates/add-preprint.hbs
+++ b/app/templates/add-preprint.hbs
@@ -24,13 +24,14 @@
                                         {{input class='form-control' value=nodeTitle}}
                                         <button class="btn btn-default" {{action 'deleteProject' (action 'changeUploadState' _State.START)}}>Back</button>
                                         {{! TODO: check if dropzone has file before allowing user to continue }}
-                                        <button class="btn btn-primary" {{action 'createProject' (action 'next' name)}}>Create</button>
+                                        <button class="btn btn-primary" {{action 'createProject'}}>Create</button>
 
                                     {{else if (eq currentUploadState _State.EXISTING)}}
                                         {{preprint-form-project-select userNodes=userNodes selectedNode=model shouldCreateChild=shouldCreateChild}}
+                                        {{! TODO: cleanup created component if needed }}
                                         <button class="btn btn-default" {{action 'changeUploadState' _State.START}}>Back</button>
                                         {{! TODO: check if dropzone has file and model exists before allowing user to continue }}
-                                        <button class="btn btn-primary" disabled={{unless model true}} {{action (if shouldCreateChild 'createChild' 'startUpload') (action 'next' name)}}>Next</button>
+                                        <button class="btn btn-primary" disabled={{unless model true}} {{action (if shouldCreateChild 'addChild' 'startUpload')}}>Next</button>
                                     {{else}}
                                         {{log 'preprint-form-upload: bad uploadState'}}
                                     {{/if}}
@@ -38,9 +39,10 @@
 
                             {{else if (eq currentState _State.EXISTING)}}
                                 {{preprint-form-project-select userNodes=userNodes fileSelect=true selectedNode=model shouldCreateChild=shouldCreateChild}}
+                                {{! TODO: cleanup created component if needed }}
                                 <button class="btn btn-default" {{action 'changeState' _State.START}}>Back</button>
                                 {{! TODO: check if project and file are selected before allowing user to continue }}
-                                <button class="btn btn-primary" disabled={{unless model true}} {{action 'next' name}}>Next</button>
+                                <button class="btn btn-primary" disabled={{unless model true}} {{action (if shouldCreateChild 'addChild' 'next') name}}>Next</button>
 
                             {{else}}
                                 {{log 'preprint-form-upload: bad state'}}

--- a/app/templates/components/preprint-form-project-select.hbs
+++ b/app/templates/components/preprint-form-project-select.hbs
@@ -33,4 +33,8 @@
             </p>
         {{/if}}
     {{/liquid-bind}}
+    <label>
+        {{input type='checkbox' checked=shouldCreateChild}}
+        Create new component for preprint
+    </label>
 {{/liquid-if}}


### PR DESCRIPTION
# Changes
- Added comments here and there
- Added checkbox to decide whether to create child component
- Added functionality to create child component

# Blocked by
- [EOSF-138: Adapter: Dirty Relationships don't fire requests until second save attempt](https://openscience.atlassian.net/browse/EOSF-138)
- [EOSF-139: Change return value](https://openscience.atlassian.net/browse/EOSF-139) of `NodeActionsMixin.actions.addChild` to child

# Ticket
Part of https://openscience.atlassian.net/browse/PREP-92