### PR TITLE
Load top level subjects into the index page and show them in two colums [PREP-106]

### DIFF
--- a/app/components/taxonomy-top-list.js
+++ b/app/components/taxonomy-top-list.js
@@ -1,0 +1,15 @@
+import Ember from 'ember';
+
+export default Ember.Component.extend({
+    sortedList: Ember.computed('list', 'list.content', function() {
+        if (!this.get('list')) {
+            return;
+        }
+        const sortedList = this.get('list').sortBy('text');
+        const pairedList = [];
+        for (let i = 0; i < sortedList.get('length'); i += 2) {
+            pairedList.pushObject([sortedList.objectAt(i), sortedList.objectAt(i + 1)]);
+        }
+        return pairedList;
+    })
+});

--- a/app/routes/index.js
+++ b/app/routes/index.js
@@ -7,7 +7,7 @@ export default Ember.Route.extend({
             theDate: new Date(),
 
             preprints: this.store.findAll('preprint'),
-            subjects: this.store.findAll('taxonomy')
+            subjects: this.store.query('taxonomy', { filter: { parent_ids: 'null' } })
         });
     },
     actions: {

--- a/app/styles/app.scss
+++ b/app/styles/app.scss
@@ -321,6 +321,17 @@ h5 {
 			1px 1px 0 black; */
         font-weight: 300;
     }
+    .subject.row {
+        list-style: none;
+        li {
+            padding: 1rem;
+            button {
+                padding: 1rem;
+                font-size: 125%;
+                width: 100%;
+            }
+        }
+    }
 }
 
 td:hover {

--- a/app/styles/app.scss
+++ b/app/styles/app.scss
@@ -325,7 +325,7 @@ h5 {
         list-style: none;
         li {
             padding: 1rem;
-            button {
+            a.btn {
                 padding: 1rem;
                 font-size: 125%;
                 width: 100%;

--- a/app/templates/components/taxonomy-top-list.hbs
+++ b/app/templates/components/taxonomy-top-list.hbs
@@ -3,7 +3,9 @@
         <ul class="subject row">
             {{#each pair as |subject|}}
                 <li class="col-md-6">
-                    <button class="btn btn-primary">{{subject.text}}</button>
+                    {{#link-to 'discover' (query-params searchString=subject.text) class='btn btn-primary'}}
+                        {{subject.text}}
+                    {{/link-to}}
                 </li>
             {{/each}}
         </ul>

--- a/app/templates/components/taxonomy-top-list.hbs
+++ b/app/templates/components/taxonomy-top-list.hbs
@@ -1,0 +1,11 @@
+<ul>
+    {{#each sortedList as |pair|}}
+        <ul class="subject row">
+            {{#each pair as |subject|}}
+                <li class="col-md-6">
+                    <button class="btn btn-primary">{{subject.text}}</button>
+                </li>
+            {{/each}}
+        </ul>
+    {{/each}}
+</ul>

--- a/app/templates/index.hbs
+++ b/app/templates/index.hbs
@@ -49,7 +49,7 @@
                 <h1 class="f-w-xl">Browse preprints by subject</h1>
                 <div class="subjectsList table-striped"> {{!SUBJECTS LIST}}
 
-                    {{taxonomy-tree tree=model.subjects filter="goToSubject"}}
+                    {{taxonomy-top-list list=model.subjects}}
 
                 </div> {{!END SUBJECTS LIST}}
             </div> {{!END CONTAINER}}

--- a/tests/integration/components/taxonomy-top-list-test.js
+++ b/tests/integration/components/taxonomy-top-list-test.js
@@ -1,0 +1,18 @@
+import { moduleForComponent, test } from 'ember-qunit';
+import hbs from 'htmlbars-inline-precompile';
+import Ember from 'ember';
+
+moduleForComponent('taxonomy-top-list', 'Integration | Component | taxonomy top list', {
+    integration: true
+});
+
+test('it renders', function(assert) {
+    // Set any properties with this.set('myProperty', 'value');
+    // Handle any actions with this.on('myAction', function(val) { ... });
+    this.set('list', Ember.A([{text: 'b'}, {text: 'a'}]));
+
+    this.render(hbs`{{taxonomy-top-list list=list}}`);
+
+    // Should be sorted as 'ab', not 'ba'
+    assert.equal(this.$().text().replace(/\s/g, ''), 'ab');
+});


### PR DESCRIPTION
# Purpose
Show top-level subjects as intended in the wireframe. Sorts the received taxonomies and links each one to a `discover` page with the subject name as the search query (there is no way to filter by subject in the `discover` page).

# Changes
- Pull list of top-level subjects from apiv2 in index route
- New component for taxonomy listing, to ease merge conflicts
- Added styling for subject buttons

![Subject list](https://cloud.githubusercontent.com/assets/5885378/17635495/b91dc746-60a5-11e6-9a65-a0a0aa7830e1.png)

# 🚫 Blocked by 🚫
- [PREP-82: Implement search page interactions](https://openscience.atlassian.net/browse/PREP-82), links to new `discover` route, which will break the component/index page if not present
- Will not show up unless on `osf.io/ember-preprints` branch until taxonomy api is merged

# Ticket
https://openscience.atlassian.net/browse/PREP-106