### PR TITLE
[quick][rfr] Change DOI regex to be closer to backend

### DIFF
--- a/app/controllers/submit.js
+++ b/app/controllers/submit.js
@@ -42,8 +42,8 @@ const BasicsValidations = buildValidations({
         description: 'DOI',
         validators: [
             validator('format', {
-                // Regex taken from http://stackoverflow.com/questions/27910/finding-a-doi-in-a-document-or-page
-                regex: /\b(10[.][0-9]{4,}(?:[.][0-9]+)*(?:(?!["&\'<>])\S)+)\b/,
+                // Simplest regex- try not to diverge too much from the backend
+                regex: /^10\.\S+\//,
                 allowBlank: true,
                 message: 'Please use a valid {description}'
             })


### PR DESCRIPTION
# Ticket
https://openscience.atlassian.net/browse/PREP-117

# Purpose
Fix issue where `doi:` was being allowed as prefix in doi field.

The regex could be tweaked to require at least one character after the slash, but we're going for consistency and simplicity here.

# Summary of changes
Make regex [more similar](https://github.com/abought/osf.io/blob/ce9cc6b7fe31620928ce6168a8cbba4bd3592a30/website/project/model.py#L772-L772) to what backend allows.