### PR TITLE
Fix tags widget regression.

### DIFF
--- a/app/templates/submit.hbs
+++ b/app/templates/submit.hbs
@@ -87,7 +87,7 @@
                                         <div>
                                             <label>
                                                 Tags:
-                                                {{input class="form-control" value=basicsTags}}
+                                                {{tags-widget addATag=(action 'addATag' node) removeATag=(action 'removeATag' node) tags=node.tags}}
                                             </label>
                                         </div>
                                     </div>


### PR DESCRIPTION
# Purpose
Restore tags widget to submit page. (OSF-style widget rather than comma-delimited text field)

Since this was already merged and reviewed, and disappeared only due to a regression, I'll go ahead and add it back in.