### PR TITLE
Fix issue with subject selector

### DIFF
--- a/app/components/subject-picker/component.js
+++ b/app/components/subject-picker/component.js
@@ -118,8 +118,8 @@ export default Ember.Component.extend({
             let index = -1;
             let selection = [...Array(tier).keys()].map(index => this.get(`selection${index + 1}`));
 
-            // An existing tag has this prefix :+1:
-            if (tier !== 3 && this.get('selected').findIndex(item => arrayStartsWith(item, selection)) !== -1) return;
+            // An existing tag has this prefix, and this is the lowest level of the taxonomy, so no need to fetch child results
+            if (tier === 3 && this.get('selected').findIndex(item => arrayStartsWith(item, selection)) !== -1) return;
 
             for (let i = 0; i < selection.length; i++) {
                 let sub = selection.slice(0, i + 1);


### PR DESCRIPTION
# Purpose
Fix a bug with the subject selector on submit page

# Steps to reproduce bug that should be fixed
1. Select a subject at the first and second levels of the taxonomy.
2. Select a third-level subject
3. Select a different second level subject
4. Select the original second-level subject. Note that the third-level section does not update with correct children.