### PR TITLE
[rfr] Fix styling of validation indicators on submit page

### DIFF
--- a/app/components/preprint-form-header.js
+++ b/app/components/preprint-form-header.js
@@ -10,13 +10,11 @@ export default CpPanelToggleComponent.extend({
     isValidationActive: false,
 
     // Calculated properties
-    noValidation: Ember.computed.empty('valid'),
-
-    invalid: Ember.computed('valid', function() {
+    invalid: Ember.computed('valid', 'isValidationActive', function() {
         // If the user hasn't even opened the panel yet, don't run the validation check
         // In other words, not true or null
         if (this.get('isValidationActive')) {
-            return this.get('valid') === false;
+            return !this.get('valid');
         } else {
             return false;
         }

--- a/app/components/preprint-form-header.js
+++ b/app/components/preprint-form-header.js
@@ -3,13 +3,24 @@ import CpPanelToggleComponent from 'ember-collapsible-panel/components/cp-panel-
 
 export default CpPanelToggleComponent.extend({
     tagName: 'header',
+    // Variables to pass in
     enabled: true,
+    showValidationIndicator: true,
+    valid: null,
+    isValidationActive: false,
 
+    // Calculated properties
     noValidation: Ember.computed.empty('valid'),
 
     invalid: Ember.computed('valid', function() {
+        // If the user hasn't even opened the panel yet, don't run the validation check
         // In other words, not true or null
-        return this.get('valid') === false;
+        if (this.get('isValidationActive')) {
+            return this.get('valid') === false;
+        } else {
+            return false;
+        }
     }),
-    classNameBindings: ['enabled::disabled', 'valid:valid', 'invalid:invalid']
+    // CSS controls icon color and display. If neither valid nor invalid state applies, don't show icon.
+    classNameBindings: ['enabled::disabled', 'valid:valid', 'invalid:invalid', 'isValidationActive::not-validated']
 });

--- a/app/components/preprint-form-section.js
+++ b/app/components/preprint-form-section.js
@@ -12,6 +12,13 @@ export default CpPanelComponent.extend({
      */
     allowOpen: false,
 
+    /**
+     * Track whether this panel has ever been opened (eg to suppress validation indicators until page is viewed)
+     * @property {boolean} hasOpened
+     */
+    hasOpened: false,
+
+
     // Fix deprecation warning
     _setup: Ember.on('init', Ember.observer('open', function() {
         this.set('panelState.boundOpenState', this.get('open'));
@@ -47,9 +54,13 @@ export default CpPanelComponent.extend({
     }),
     // Called when panel is toggled
     handleToggle() {
+        // TODO: When panel is opened, make sure a property is set to indicate that section has now been viewed
+
+
         // Prevent closing all views
         if (!this.get('isOpen')) {
             if (this.get('allowOpen')) {
+                this.set('hasOpened', true);
                 // Crude mechanism to prevent opening a panel if conditions are not met
                 this._super(...arguments);
             } else {

--- a/app/components/preprint-form-section.js
+++ b/app/components/preprint-form-section.js
@@ -18,6 +18,13 @@ export default CpPanelComponent.extend({
      */
     hasOpened: false,
 
+    trackOpenState: Ember.observer('isOpen', function() {
+        // Whenever panel is opened (via any means), update the hasOpened state to reflect this fact
+        let isOpen = this.get('isOpen');
+        if (isOpen) {
+            this.set('hasOpened', true);
+        }
+    }),
 
     // Fix deprecation warning
     _setup: Ember.on('init', Ember.observer('open', function() {
@@ -54,13 +61,9 @@ export default CpPanelComponent.extend({
     }),
     // Called when panel is toggled
     handleToggle() {
-        // TODO: When panel is opened, make sure a property is set to indicate that section has now been viewed
-
-
         // Prevent closing all views
         if (!this.get('isOpen')) {
             if (this.get('allowOpen')) {
-                this.set('hasOpened', true);
                 // Crude mechanism to prevent opening a panel if conditions are not met
                 this._super(...arguments);
             } else {

--- a/app/controllers/submit.js
+++ b/app/controllers/submit.js
@@ -78,8 +78,8 @@ export default Ember.Controller.extend(BasicsValidations, NodeActionsMixin, Tagg
     basicsValid: Ember.computed.alias('validations.isValid'),
     // Must have at least one contributor. Backend enforces admin and bibliographic rules. If this form section is ever invalid, something has gone horribly wrong.
     authorsValid: Ember.computed.bool('contributors.length'),
-    // Must select at least one subject. TODO: Verify this is the appropriate way to track
-    subjectsValid: Ember.computed.bool('model.subjects.length'),
+    // Must select at least one subject.
+    subjectsValid: Ember.computed.notEmpty('model.subjects'),
 
     ////////////////////////////////////////////////////
     // Fields used in the "basics" section of the form.

--- a/app/routes/submit.js
+++ b/app/routes/submit.js
@@ -9,7 +9,9 @@ export default Ember.Route.extend(AuthenticatedRouteMixin, {
     model() {
         // Store the empty preprint to be created on the model hook for page. Node will be fetched
         //  internally during submission process.
-        return this.store.createRecord('preprint');
+        return this.store.createRecord('preprint', {
+            subjects: []
+        });
     },
     setupController(controller) {
         // Fetch values required to operate the page: user and userNodes

--- a/app/styles/app.scss
+++ b/app/styles/app.scss
@@ -509,11 +509,16 @@ hr {
                 display: block;
             }
         }
+        &.not-validated {
+            .preprint-section-status .fa {
+                color: gray;
+                display: block;
+            }
+        }
         .fa {
             font-size: 20px;
         }
         .preprint-section-status .fa {
-            color: gray;
             transition: color 0.1s linear;
             display: none;
         }

--- a/app/styles/app.scss
+++ b/app/styles/app.scss
@@ -520,7 +520,6 @@ hr {
         }
         .preprint-section-status .fa {
             transition: color 0.1s linear;
-            display: none;
         }
     }
     .cp-Panel-body {

--- a/app/templates/components/preprint-form-header.hbs
+++ b/app/templates/components/preprint-form-header.hbs
@@ -1,8 +1,10 @@
 {{name}}
 <div class="preprint-section-status pull-right">
-    {{#if (or valid noValidation)}}
-        {{fa-icon 'check-circle'}}
-    {{else}}
-        {{fa-icon 'times-circle'}}
+    {{#if showValidationIndicator}}
+        {{#if (or valid (not isValidationActive))}}
+            {{fa-icon 'check-circle'}}
+        {{else}}
+            {{fa-icon 'times-circle'}}
+        {{/if}}
     {{/if}}
 </div>

--- a/app/templates/components/preprint-form-section.hbs
+++ b/app/templates/components/preprint-form-section.hbs
@@ -1,1 +1,1 @@
-{{yield}}
+{{yield hasOpened}}

--- a/app/templates/submit.hbs
+++ b/app/templates/submit.hbs
@@ -15,8 +15,8 @@
                 <p>Use the guide below to add your preprint to the OSF preprint service. We organize preprints into projects that provide many additional features and options. Learn more about how to work with preprints and projects in OSF. </p>
                 {{#cp-panels accordion=true}}
                     {{#with _names.[0] as |name|}}
-                        {{#preprint-form-section id='preprint-form-upload' class="preprint-form-block" open=true name=name allowOpen=true errorAction=(action 'error')}}
-                            {{preprint-form-header name=name valid=uploadValid}}
+                        {{#preprint-form-section id='preprint-form-upload' class="preprint-form-block" open=true name=name allowOpen=true errorAction=(action 'error') as |hasOpened|}}
+                            {{preprint-form-header name=name showValidationIndicator=false}}
                             {{#preprint-form-body}}
                                 {{#if fileAndNodeLocked}}
                                     <p><label> Selected File: </label> {{selectedFile.name}}</p>
@@ -75,8 +75,9 @@
                     {{/with}}
 
                     {{#with _names.[1] as |name|}}
-                        {{#preprint-form-section id='preprint-form-basics' class="preprint-form-block" name=name allowOpen=uploadValid errorAction=(action 'error')}}
-                            {{preprint-form-header name=name valid=basicsValid}}
+                        {{#preprint-form-section id='preprint-form-basics' class="preprint-form-block" name=name allowOpen=uploadValid errorAction=(action 'error') as |hasOpened|}}
+                            {{log 'Basics Section hasopened state' hasOpened}}
+                            {{preprint-form-header name=name valid=basicsValid isValidationActive=hasOpened}}
                             {{#preprint-form-body}}
                                 <div class="row">
                                     <div class="col-md-6">
@@ -119,8 +120,8 @@
                     {{/with}}
 
                     {{#with _names.[2] as |name|}}
-                        {{#preprint-form-section id='preprint-form-subjects' class="preprint-form-block"  name=name allowOpen=uploadValid errorAction=(action 'error')}}
-                            {{preprint-form-header name=name valid=subjectsValid}}
+                        {{#preprint-form-section id='preprint-form-subjects' class="preprint-form-block"  name=name allowOpen=uploadValid errorAction=(action 'error') as |hasOpened|}}
+                            {{preprint-form-header name=name valid=subjectsValid isValidationActive=hasOpened}}
                             {{#preprint-form-body}}
 
                                 {{subject-picker save=(action 'saveSubjects')}}
@@ -137,8 +138,8 @@
                     {{/with}}
 
                     {{#with _names.[3] as |name|}}
-                        {{#preprint-form-section id='preprint-form-authors' class="preprint-form-block"  name=name allowOpen=uploadValid errorAction=(action 'error')}}
-                            {{preprint-form-header name=name valid=authorsValid}}
+                        {{#preprint-form-section id='preprint-form-authors' class="preprint-form-block"  name=name allowOpen=uploadValid errorAction=(action 'error') as |hasOpened|}}
+                            {{preprint-form-header name=name valid=authorsValid isValidationActive=hasOpened}}
                             {{#preprint-form-body}}
                                 {{preprint-form-authors
                                     contributors=contributors
@@ -166,8 +167,8 @@
                     {{/with}}
 
                     {{#with _names.[4] as |name|}}
-                        {{#preprint-form-section id='preprint-form-submit' class="preprint-form-block"  animate=true name=name allowOpen=uploadValid errorAction=(action 'error')}}
-                            {{preprint-form-header name=name valid=(get valid name)}}
+                        {{#preprint-form-section id='preprint-form-submit' class="preprint-form-block"  animate=true name=name allowOpen=uploadValid errorAction=(action 'error') as |hasOpened|}}
+                            {{preprint-form-header name=name showValidationIndicator=false}}
                             {{#cp-panel-body}}
                                 <div class="text-center">
                                     <p>Sharing this project will make both the manuscript and the project associated with it public.</p>


### PR DESCRIPTION
# Purpose
Don't show an error icon (bad data) if the user hasn't even visited that panel yet.

## Future notes
Of course, this does mean we will want some additional validation before the user clicks submit- if they skip a section, they could end up sending bad data to the server without realizing it, because the empty field was on a tab that never ran validators to show a checkmark for (eg server will allow an empty abstract even though UI doesn't)... 

Not sure where the best place in the UI is for a "final validation check", though. @caneruguz ?

![screen shot 2016-08-24 at 3 44 04 pm](https://cloud.githubusercontent.com/assets/2957073/17945408/baff39d0-6a11-11e6-9fa4-596bbbfac655.png)
