### PR TITLE
WIP/Feature Submit Form Polishing

### DIFF
--- a/app/components/preprint-form-section.js
+++ b/app/components/preprint-form-section.js
@@ -67,7 +67,7 @@ export default CpPanelComponent.extend({
                 // Crude mechanism to prevent opening a panel if conditions are not met
                 this._super(...arguments);
             } else {
-                this.sendAction('errorAction', 'Please select a project and file before continuing');
+                this.sendAction('errorAction', 'Please complete upload section before continuing');
             }
         }
     },

--- a/app/controllers/submit.js
+++ b/app/controllers/submit.js
@@ -259,8 +259,15 @@ export default Ember.Controller.extend(BasicsValidations, NodeActionsMixin, Tagg
 
                 _this.$('#' + elementId).addClass(highlightClass);
                 setTimeout(() => {
+                    _this.$('#' + elementId).addClass('restoreWhiteBackground');
+
+                }, 2000);
+                 setTimeout(() => {
                     _this.$('#' + elementId).removeClass(highlightClass);
+                    _this.$('#' + elementId).removeClass('restoreWhiteBackground');
                 }, 4000);
+
+
             });
         },
         /*

--- a/app/controllers/submit.js
+++ b/app/controllers/submit.js
@@ -80,6 +80,9 @@ export default Ember.Controller.extend(BasicsValidations, NodeActionsMixin, Tagg
     authorsValid: Ember.computed.bool('contributors.length'),
     // Must select at least one subject.
     subjectsValid: Ember.computed.notEmpty('model.subjects'),
+    allSectionsValid: Ember.computed('uploadValid', 'basicsValid', 'authorsValid', 'subjectsValid', function() {
+        return this.get('uploadValid') && this.get('basicsValid') && this.get('authorsValid') && this.get('subjectsValid');
+    }),
 
     ////////////////////////////////////////////////////
     // Fields used in the "basics" section of the form.

--- a/app/controllers/submit.js
+++ b/app/controllers/submit.js
@@ -93,6 +93,9 @@ export default Ember.Controller.extend(BasicsValidations, NodeActionsMixin, Tagg
     basicsAbstract: Ember.computed.alias('basicsModel.description'),
     basicsTags: Ember.computed.alias('basicsModel.tags'), // TODO: This may need to provide a default value (list)? Via default or field transform?
     basicsDOI: Ember.computed.alias('model.doi'),
+    basicsSaveState: false,
+    subjectsSaveState: false,
+    authorsSaveState: false,
 
     //// TODO: Turn off autosave functionality for now. Direct 2-way binding was causing a fight between autosave and revalidation, so autosave never fired. Fixme.
     // createAutosave: Ember.observer('node', function() {
@@ -160,6 +163,15 @@ export default Ember.Controller.extend(BasicsValidations, NodeActionsMixin, Tagg
         // Open next panel
         next(currentPanelName) {
             this.get('panelActions').open(this.get(`_names.${this.get('_names').indexOf(currentPanelName) + 1}`));
+            this.send('changesSaved', currentPanelName);
+        },
+        changesSaved(currentPanelName){
+            var currentPanelSaveState = currentPanelName.toLowerCase() + 'SaveState';
+            this.set(currentPanelSaveState, true);
+            setTimeout(() => {
+                this.set(currentPanelSaveState, false);
+
+            }, 3000);
         },
 
         error(error /*, transition */) {

--- a/app/controllers/submit.js
+++ b/app/controllers/submit.js
@@ -165,7 +165,7 @@ export default Ember.Controller.extend(BasicsValidations, NodeActionsMixin, Tagg
             this.get('panelActions').open(this.get(`_names.${this.get('_names').indexOf(currentPanelName) + 1}`));
             this.send('changesSaved', currentPanelName);
         },
-        changesSaved(currentPanelName){
+        changesSaved(currentPanelName) {
             var currentPanelSaveState = currentPanelName.toLowerCase() + 'SaveState';
             this.set(currentPanelSaveState, true);
             setTimeout(() => {
@@ -274,12 +274,10 @@ export default Ember.Controller.extend(BasicsValidations, NodeActionsMixin, Tagg
                     _this.$('#' + elementId).addClass('restoreWhiteBackground');
 
                 }, 2000);
-                 setTimeout(() => {
+                setTimeout(() => {
                     _this.$('#' + elementId).removeClass(highlightClass);
                     _this.$('#' + elementId).removeClass('restoreWhiteBackground');
                 }, 4000);
-
-
             });
         },
         /*

--- a/app/styles/app.scss
+++ b/app/styles/app.scss
@@ -807,3 +807,7 @@ hr {
 #convertExistingOrCreateComponent {
     padding-left: 15px;
 }
+
+.toast {
+    opacity: 1 !important;
+}

--- a/app/styles/app.scss
+++ b/app/styles/app.scss
@@ -500,19 +500,16 @@ hr {
         &.valid {
             .preprint-section-status .fa {
                 color: #009688;
-                display: block;
             }
         }
         &.invalid {
             .preprint-section-status .fa {
                 color: #F44336;
-                display: block;
             }
         }
         &.not-validated {
             .preprint-section-status .fa {
                 color: gray;
-                display: block;
             }
         }
         .fa {

--- a/app/styles/authors.scss
+++ b/app/styles/authors.scss
@@ -117,6 +117,16 @@ span.sortable-bars:hover {
     animation-direction: alternate;
 }
 
+.restoreWhiteBackground{
+    background-color: white !important;
+    -webkit-transition: background-color 1500ms linear;
+    -moz-transition: background-color 1500ms linear;
+    -o-transition: background-color 1500ms linear;
+    transition: background-color 1500ms linear;
+    -webkit-animation-direction: alternate;
+    animation-direction: alternate;
+}
+
 .errorHighlight{
     background-color: #F2DEDE !important;
     -webkit-transition: background-color 1500ms linear;

--- a/app/templates/components/preprint-form-header.hbs
+++ b/app/templates/components/preprint-form-header.hbs
@@ -1,44 +1,11 @@
 {{name}}
 
 {{#if (and (not isOpen) (eq name 'Upload'))}}
-    <p><label> Preprint file: </label> {{preprintFile}} </p>
-    <p><label> Preprint title: </label> {{preprintTitle}} </p>
+    <div class="m-t-md">
+        <p><label> Preprint file: </label> {{preprintFile}} </p>
+        <p><label> Preprint title: </label> {{preprintTitle}} </p>
+    </div>
 {{/if}}
-
-{{#if (and isValidationActive (not isOpen))}}
-    {{#if (eq name 'Basics')}}
-        <p><label> DOI: </label> {{if doi doi 'None'}} </p>
-        <p>
-            <label> Tags: </label>
-            {{#if tags}}
-                {{#each tags as |tag|}}
-                    <span> tag </span>
-                {{/each}}
-            {{else}}
-                None
-            {{/if}}
-        </p>
-        <p><label> Abstract: </label> {{if abstract abstract 'None'}} </p>
-    {{else if (eq name 'Subjects')}}
-        {{#if subjects.[0]}}
-            {{#each subjects as |subject|}}
-                <p>{{subject.text}} </p>
-            {{/each}}
-        {{else}}
-            <p> None </p>
-        {{/if}}
-
-    {{else if (eq name 'Authors')}}
-        {{#each authors as |contrib|}}
-            {{#if contrib.unregisteredContributor}}
-                <p>{{contrib.unregisteredContributor}}</p>
-            {{else}}
-                <p>{{contrib.users.fullName}} </p>
-            {{/if}}
-        {{/each}}
-    {{/if}}
-{{/if}}
-
 
 <div class="preprint-section-status pull-right">
     {{#if showValidationIndicator}}
@@ -49,3 +16,40 @@
         {{/if}}
     {{/if}}
 </div>
+
+{{#if (and isValidationActive (not isOpen))}}
+    <div class="m-t-md">
+        {{#if (eq name 'Basics')}}
+            <p><label> DOI: </label> {{if doi doi 'None'}} </p>
+            <p>
+                <label> Tags: </label>
+                {{#if tags}}
+                    {{#each tags as |tag|}}
+                        <span> tag </span>
+                    {{/each}}
+                {{else}}
+                    None
+                {{/if}}
+            </p>
+            <p><label> Abstract: </label> {{if abstract abstract 'None'}} </p>
+        {{else if (eq name 'Subjects')}}
+            {{#if subjects}}
+                {{#each subjects as |subject|}}
+                    <p>{{subject.text}} </p>
+                {{/each}}
+            {{else}}
+                <p> None </p>
+            {{/if}}
+
+        {{else if (eq name 'Authors')}}
+            {{#each authors as |contrib|}}
+                {{#if contrib.unregisteredContributor}}
+                    <p>{{contrib.unregisteredContributor}}</p>
+                {{else}}
+                    <p>{{contrib.users.fullName}} </p>
+                {{/if}}
+            {{/each}}
+        {{/if}}
+    </div>
+{{/if}}
+

--- a/app/templates/components/preprint-form-header.hbs
+++ b/app/templates/components/preprint-form-header.hbs
@@ -8,20 +8,20 @@
 {{/if}}
 
 <div class="preprint-section-status pull-right">
-        {{#if (and basicsSaveState (eq name 'Basics'))}}
-             <span class="text-success m-r-md"> Changes Saved! </span>
-        {{else if (and authorsSaveState (eq name 'Authors'))}}
-             <span class="text-success m-r-md"> Changes Saved! </span>
-        {{else if (and subjectsSaveState (eq name 'Subjects'))}}
-             <span class="text-success m-r-md"> Changes Saved! </span>
+    {{#if (and basicsSaveState (eq name 'Basics'))}}
+        <span class="text-success m-r-md"> Changes Saved! </span>
+    {{else if (and authorsSaveState (eq name 'Authors'))}}
+        <span class="text-success m-r-md"> Changes Saved! </span>
+    {{else if (and subjectsSaveState (eq name 'Subjects'))}}
+        <span class="text-success m-r-md"> Changes Saved! </span>
+    {{/if}}
+    {{#if showValidationIndicator}}
+        {{#if (or valid (not isValidationActive))}}
+            {{fa-icon 'check-circle'}}
+        {{else}}
+            {{fa-icon 'times-circle'}}
         {{/if}}
-        {{#if showValidationIndicator}}
-            {{#if (or valid (not isValidationActive))}}
-                {{fa-icon 'check-circle'}}
-            {{else}}
-                {{fa-icon 'times-circle'}}
-            {{/if}}
-        {{/if}}
+    {{/if}}
 </div>
 
 {{#if (and isValidationActive (not isOpen))}}

--- a/app/templates/components/preprint-form-header.hbs
+++ b/app/templates/components/preprint-form-header.hbs
@@ -1,5 +1,45 @@
 {{name}}
-{{secondary-info}}
+
+{{#if (and (not isOpen) (eq name 'Upload'))}}
+    <p><label> Preprint file: </label> {{preprintFile}} </p>
+    <p><label> Preprint title: </label> {{preprintTitle}} </p>
+{{/if}}
+
+{{#if (and isValidationActive (not isOpen))}}
+    {{#if (eq name 'Basics')}}
+        <p><label> DOI: </label> {{if doi doi 'None'}} </p>
+        <p>
+            <label> Tags: </label>
+            {{#if tags}}
+                {{#each tags as |tag|}}
+                    <span> tag </span>
+                {{/each}}
+            {{else}}
+                None
+            {{/if}}
+        </p>
+        <p><label> Abstract: </label> {{if abstract abstract 'None'}} </p>
+    {{else if (eq name 'Subjects')}}
+        {{#if subjects}}
+            {{#each subjects as |subject|}}
+                <p>{{subject.text}} </p>
+            {{/each}}
+        {{else}}
+            None
+        {{/if}}
+
+
+    {{else if (eq name 'Authors')}}
+        {{#each authors as |contrib|}}
+            {{#if contrib.unregisteredContributor}}
+                <p>{{contrib.unregisteredContributor}}</p>
+            {{else}}
+                <p>{{contrib.users.fullName}} </p>
+            {{/if}}
+        {{/each}}
+    {{/if}}
+{{/if}}
+
 
 <div class="preprint-section-status pull-right">
     {{#if showValidationIndicator}}

--- a/app/templates/components/preprint-form-header.hbs
+++ b/app/templates/components/preprint-form-header.hbs
@@ -20,14 +20,13 @@
         </p>
         <p><label> Abstract: </label> {{if abstract abstract 'None'}} </p>
     {{else if (eq name 'Subjects')}}
-        {{#if subjects}}
+        {{#if subjects.[0]}}
             {{#each subjects as |subject|}}
                 <p>{{subject.text}} </p>
             {{/each}}
         {{else}}
-            None
+            <p> None </p>
         {{/if}}
-
 
     {{else if (eq name 'Authors')}}
         {{#each authors as |contrib|}}

--- a/app/templates/components/preprint-form-header.hbs
+++ b/app/templates/components/preprint-form-header.hbs
@@ -8,13 +8,20 @@
 {{/if}}
 
 <div class="preprint-section-status pull-right">
-    {{#if showValidationIndicator}}
-        {{#if (or valid (not isValidationActive))}}
-            {{fa-icon 'check-circle'}}
-        {{else}}
-            {{fa-icon 'times-circle'}}
+        {{#if (and basicsSaveState (eq name 'Basics'))}}
+             <span class="text-success m-r-md"> Changes Saved! </span>
+        {{else if (and authorsSaveState (eq name 'Authors'))}}
+             <span class="text-success m-r-md"> Changes Saved! </span>
+        {{else if (and subjectsSaveState (eq name 'Subjects'))}}
+             <span class="text-success m-r-md"> Changes Saved! </span>
         {{/if}}
-    {{/if}}
+        {{#if showValidationIndicator}}
+            {{#if (or valid (not isValidationActive))}}
+                {{fa-icon 'check-circle'}}
+            {{else}}
+                {{fa-icon 'times-circle'}}
+            {{/if}}
+        {{/if}}
 </div>
 
 {{#if (and isValidationActive (not isOpen))}}

--- a/app/templates/submit.hbs
+++ b/app/templates/submit.hbs
@@ -43,7 +43,7 @@
                     {{#with _names.[1] as |name|}}
                         {{#preprint-form-section id='preprint-form-basics' class="preprint-form-block" name=name allowOpen=uploadValid errorAction=(action 'error') as |hasOpened|}}
                             {{log 'Basics Section hasopened state' hasOpened}}
-                            {{preprint-form-header doi=basicsDOI tags=node.tags abstract=basicsAbstract name=name valid=basicsValid isValidationActive=hasOpened}}
+                            {{preprint-form-header doi=basicsDOI basicsSaveState=basicsSaveState tags=node.tags abstract=basicsAbstract name=name valid=basicsValid isValidationActive=hasOpened}}
                             {{#preprint-form-body}}
                                 <div class="row">
                                     <div class="col-md-6">
@@ -81,7 +81,7 @@
 
                     {{#with _names.[2] as |name|}}
                         {{#preprint-form-section id='preprint-form-subjects' class="preprint-form-block"  name=name allowOpen=uploadValid errorAction=(action 'error') as |hasOpened|}}
-                            {{preprint-form-header subjects=model.subjects name=name valid=subjectsValid isValidationActive=hasOpened}}
+                            {{preprint-form-header subjectsSaveState=subjectsSaveState subjects=model.subjects name=name valid=subjectsValid isValidationActive=hasOpened}}
                             {{#preprint-form-body}}
 
                                 {{subject-picker save=(action 'saveSubjects')}}
@@ -99,7 +99,7 @@
 
                     {{#with _names.[3] as |name|}}
                         {{#preprint-form-section id='preprint-form-authors' class="preprint-form-block"  name=name allowOpen=uploadValid errorAction=(action 'error') as |hasOpened|}}
-                            {{preprint-form-header authors=contributors name=name valid=authorsValid isValidationActive=hasOpened}}
+                            {{preprint-form-header authorsSaveState=authorsSaveState authors=contributors name=name valid=authorsValid isValidationActive=hasOpened}}
                             {{#preprint-form-body}}
                                 {{preprint-form-authors
                                     contributors=contributors

--- a/app/templates/submit.hbs
+++ b/app/templates/submit.hbs
@@ -132,6 +132,13 @@
                             {{#cp-panel-body}}
                                 <div class="text-center">
                                     <p>Sharing this project will make both the manuscript and the project associated with it public.</p>
+                                    {{#unless allSectionsValid}}
+                                        <p class="m-t-md"> <strong> The following section(s) must be completed before sharing this preprint. </strong></p>
+                                        <p class="text-danger"> {{if (not basicsValid) 'Basics'}}</p>
+                                        <p class="text-danger"> {{if (not subjectsValid) 'Subjects'}}</p>
+                                        <p class="text-danger"> {{if (not authorsValid) 'Authors'}}</p>
+                                    {{/unless}}
+                                    <p> </p>
                                     <button class="btn btn-primary btn-lg m-t-md" disabled={{unless allSectionsValid true}} type="submit" {{action 'savePreprint'}}>Share</button>
                                 </div>
                             {{/cp-panel-body}}

--- a/app/templates/submit.hbs
+++ b/app/templates/submit.hbs
@@ -132,7 +132,7 @@
                             {{#cp-panel-body}}
                                 <div class="text-center">
                                     <p>Sharing this project will make both the manuscript and the project associated with it public.</p>
-                                    <button class="btn btn-primary btn-lg m-t-md" disabled={{unless authorsValid true}} type="submit" {{action 'savePreprint'}}>Share</button>
+                                    <button class="btn btn-primary btn-lg m-t-md" disabled={{unless allSectionsValid true}} type="submit" {{action 'savePreprint'}}>Share</button>
                                 </div>
                             {{/cp-panel-body}}
                         {{/preprint-form-section}}

--- a/app/templates/submit.hbs
+++ b/app/templates/submit.hbs
@@ -16,7 +16,7 @@
                 {{#cp-panels accordion=true}}
                     {{#with _names.[0] as |name|}}
                         {{#preprint-form-section id='preprint-form-upload' class="preprint-form-block" open=true name=name allowOpen=true errorAction=(action 'error')}}
-                            {{preprint-form-header showValidationIndicator=false name=name secondary-info=(if node.title (concat "Preprint title: " node.title) '') valid=uploadValid}}
+                            {{preprint-form-header showValidationIndicator=false name=name preprintFile=selectedFile.name preprintTitle=node.title valid=uploadValid}}
                             {{#preprint-form-body}}
                                 {{#if fileAndNodeLocked}}
                                     <p><label> Preprint file: </label> {{selectedFile.name}}</p>
@@ -43,7 +43,7 @@
                     {{#with _names.[1] as |name|}}
                         {{#preprint-form-section id='preprint-form-basics' class="preprint-form-block" name=name allowOpen=uploadValid errorAction=(action 'error') as |hasOpened|}}
                             {{log 'Basics Section hasopened state' hasOpened}}
-                            {{preprint-form-header name=name valid=basicsValid isValidationActive=hasOpened}}
+                            {{preprint-form-header doi=basicsDOI tags=node.tags abstract=basicsAbstract name=name valid=basicsValid isValidationActive=hasOpened}}
                             {{#preprint-form-body}}
                                 <div class="row">
                                     <div class="col-md-6">
@@ -81,7 +81,7 @@
 
                     {{#with _names.[2] as |name|}}
                         {{#preprint-form-section id='preprint-form-subjects' class="preprint-form-block"  name=name allowOpen=uploadValid errorAction=(action 'error') as |hasOpened|}}
-                            {{preprint-form-header name=name valid=subjectsValid isValidationActive=hasOpened}}
+                            {{preprint-form-header subjects=model.subjects name=name valid=subjectsValid isValidationActive=hasOpened}}
                             {{#preprint-form-body}}
 
                                 {{subject-picker save=(action 'saveSubjects')}}
@@ -99,7 +99,7 @@
 
                     {{#with _names.[3] as |name|}}
                         {{#preprint-form-section id='preprint-form-authors' class="preprint-form-block"  name=name allowOpen=uploadValid errorAction=(action 'error') as |hasOpened|}}
-                            {{preprint-form-header name=name valid=authorsValid isValidationActive=hasOpened}}
+                            {{preprint-form-header authors=contributors name=name valid=authorsValid isValidationActive=hasOpened}}
                             {{#preprint-form-body}}
                                 {{preprint-form-authors
                                     contributors=contributors
@@ -132,7 +132,7 @@
                             {{#cp-panel-body}}
                                 <div class="text-center">
                                     <p>Sharing this project will make both the manuscript and the project associated with it public.</p>
-                                    <button class="btn btn-primary btn-lg m-t-md" type="submit" {{action 'savePreprint'}}>Share</button>
+                                    <button class="btn btn-primary btn-lg m-t-md" disabled={{unless authorsValid true}} type="submit" {{action 'savePreprint'}}>Share</button>
                                 </div>
                             {{/cp-panel-body}}
                         {{/preprint-form-section}}


### PR DESCRIPTION
# Changes

Modifies submit form

- [x] Make toastr messages opaque
- [x] Read-only feedback in form header once user has visited section
- [x] Disable 'Share' button until all pieces of form are complete
- [x] Slow down fade out of green/red highlight on success/failure
- [x] Show form sections with problems in share section until corrected
- [x] Modify toastr message that flashes when user tries to advance before upload state is complete
- [x] Flash changes saved in form header when user hits 'Save and continue'
- [ ] Add modal requiring user to confirm they want to submit preprint
- [ ] After save, scroll to position of next div
- [ ] Be able to edit title after passing upload step