### PR TITLE
Use proposed changes to ember OSF's addContributor method

### DIFF
--- a/app/components/preprint-form-authors.js
+++ b/app/components/preprint-form-authors.js
@@ -30,7 +30,7 @@ export default CpPanelBodyComponent.extend({
     actions: {
         // Adds contributor then redraws view - addition of contributor may change which update/remove contributor requests are permitted
         addContributor(user) {
-            this.attrs.addContributor(user.id, 'write', true, undefined, undefined, true).then((res) => {
+            this.attrs.addContributor(user.id, 'write', true, false, undefined, undefined, true).then((res) => {
                 this.toggleAuthorModification();
                 this.get('contributors').pushObject(res);
                 this.highlightSuccessOrFailure(res.id, this, 'success');
@@ -43,7 +43,7 @@ export default CpPanelBodyComponent.extend({
         // Adds unregistered contributor, then clears form and switches back to search view.
         // Should wait to transition until request has completed.
         addUnregisteredContributor(fullName, email) {
-            let res = this.attrs.addContributor(null, 'write', true, fullName, email, true);
+            let res = this.attrs.addContributor(null, 'write', true, false, fullName, email, true);
             res.then((contributor) => {
                 this.get('contributors').pushObject(contributor);
                 this.toggleAuthorModification();

--- a/app/components/supplementary-file-browser.js
+++ b/app/components/supplementary-file-browser.js
@@ -25,7 +25,7 @@ export default Ember.Component.extend({
         this.get('preprint').query('files', {'filter[name]': 'osfstorage'})
             .then(providers => {
                 this.set('provider', providers.get('firstObject'));
-                return this.get('provider').query('files', {'page[size]': 10})
+                return this.get('provider').query('files', {'page[size]': 10});
             })
             .then(files => this.set('files', files))
             .then(() => {


### PR DESCRIPTION
**note** Relies on CenterForOpenScience/ember-osf#125
and later: https://github.com/CenterForOpenScience/osf.io/pull/6218

Proposed changes in https://github.com/CenterForOpenScience/ember-osf/pull/125 allows you to pass along a send_email=false query parameter to the OSF API that will allow preprint contributor emails to be sent only after the preprint process has been completed.

This PR sends the signal through the addContributor method, whic on ember OSf side will send the right API request that then will trigger the emails proposed in the OSF PR that the authors have been added to a *preprint* as opposed to a confusing project!