### PR TITLE
[rfr] Fix whitespace in comma separated lists on authors, tags

### DIFF
--- a/app/components/author-link/component.js
+++ b/app/components/author-link/component.js
@@ -2,8 +2,9 @@ import Ember from 'ember';
 
 export default Ember.Component.extend({
     tagName: 'li',
+    contributor: null,
 
-    profileLink: function() {
+    profileLink: Ember.computed('contributor', function() {
         let ids = this.get('contributor.users.identifiers');
 
         for (let i = 0; i < ids.length; i++)
@@ -11,6 +12,5 @@ export default Ember.Component.extend({
                     return ids[i].url;
 
         return false;
-    }.property('contributor')
-
+    })
 });

--- a/app/components/author-link/template.hbs
+++ b/app/components/author-link/template.hbs
@@ -1,7 +1,7 @@
-{{#if profileLink}}
+{{#if profileLink~}}
     <a href={{profileLink}}>
-        {{contributor.users.familyName}}{{if contributor.users.familyName ', '}}{{contributor.users.givenName}}
+        {{contributor.users.givenName}} {{contributor.users.familyName}}
     </a>
 {{else}}
-    {{contributor.users.familyName}}{{if contributor.users.familyName ', '}}{{contributor.users.givenName}}
-{{/if}}
+    {{contributor.users.givenName}} {{contributor.users.familyName}}
+{{~/if}}

--- a/app/mixins/reset-scroll.js
+++ b/app/mixins/reset-scroll.js
@@ -1,8 +1,8 @@
 import Ember from 'ember';
 
 export default Ember.Mixin.create({
-  activate: function() {
-      this._super();
-      window.scrollTo(0,0);
-  }
+    activate: function() {
+        this._super();
+        window.scrollTo(0, 0);
+    }
 });

--- a/app/templates/components/preprint-form-header.hbs
+++ b/app/templates/components/preprint-form-header.hbs
@@ -35,9 +35,9 @@
                 <b class="m-r-md"> Tags: </b>
                 {{#if tags}}
                     <ul class="comma-list">
-                        {{#each tags as |tag|}}
-                            <li> {{tag}} </li>
-                        {{/each}}
+                        {{#each tags as |tag|~}}
+                            <li> {{~tag~}} </li>
+                        {{~/each}}
                     </ul>
                 {{else}}
                     <span> None</span>
@@ -55,15 +55,15 @@
 
         {{else if (eq name 'Authors')}}
             <ul class="author-preview comma-list">
-                {{#each authors as |contrib|}}
+                {{#each authors as |contrib| ~}}
                     <li>
-                        {{#if contrib.unregisteredContributor}}
-                            {{contrib.unregisteredContributor}}
+                        {{~#if contrib.unregisteredContributor~}}
+                            {{~contrib.unregisteredContributor~}}
                         {{else}}
-                            {{contrib.users.fullName}}
-                        {{/if}}
+                            {{~contrib.users.fullName~}}
+                        {{~/if~}}
                     </li>
-                {{/each}}
+                {{~/each}}
             </ul>
         {{/if}}
 

--- a/app/templates/content.hbs
+++ b/app/templates/content.hbs
@@ -3,9 +3,9 @@
         <div class="container">{{!CONTAINER DIV}}
             <h1 class="p-b-md">{{model.title}}</h1>
             <h5 class="view-authors">
-                {{#each model.contributors as |author index|}}
-                    {{if index ', ' ''}}<a href={{author.users.profileURL}}>{{author.users.fullName}}</a>
-                {{/each}}
+                {{#each model.contributors as |author index| ~}}
+                    {{~if index ', ' ''}}<a href={{author.users.profileURL}}>{{author.users.fullName}}</a>
+                {{~/each}}
             </h5>
             <h6>Added on: {{moment-format model.date_created "MMMM DD, YYYY"}} | Last edited: {{moment-format model.date_modified "MMMM DD, YYYY"}} </h6>
         </div> {{!END CONTAINER DIV}}


### PR DESCRIPTION
# Purpose

Fix whitespace around author and tag names on the submit page (header previews) and detail page (authors list) by applying handlebars whitespace control syntax.

![screen shot 2016-08-27 at 4 45 22 pm](https://cloud.githubusercontent.com/assets/2957073/18030037/1b48121e-6c77-11e6-9c4a-4f3b4e270765.png)
![screen shot 2016-08-27 at 4 51 47 pm](https://cloud.githubusercontent.com/assets/2957073/18030038/1b4c6616-6c77-11e6-8450-a50c3e97ec05.png)


# Ticket
https://trello.com/c/oRldPiU4/64-whitespace-between-commas-on-tags-and-authors-on-submit-page