### PR TITLE
Set fileprovider manually on ember side

### DIFF
--- a/app/components/supplementary-file-browser.js
+++ b/app/components/supplementary-file-browser.js
@@ -22,9 +22,9 @@ export default Ember.Component.extend({
         this._super(...arguments);
 
         this.set('files', []);
-        this.get('preprint').query('files', {'filter[name]': 'osfstorage'})
+        this.get('preprint').get('files')
             .then(providers => {
-                this.set('provider', providers.get('firstObject'));
+                this.set('provider', providers.findBy('name', 'osfstorage'));
                 return this.get('provider').query('files', {'page[size]': 10});
             })
             .then(files => this.set('files', files))


### PR DESCRIPTION
## Purpose
OSF API v2 does not currently support filtering the file provider list, so we were getting all storage options. This sets the provider manually by looking through the provider list for 

## Changes
- Use ember `findBy` instead of an API filter to only get files from osfstorage

## Ticket
https://trello.com/c/yDkOiFju/58-attaching-add-on-folder-breaks-preprint