### PR TITLE
[quick] Search result layout and author name order

### DIFF
--- a/app/templates/components/search-result.hbs
+++ b/app/templates/components/search-result.hbs
@@ -45,9 +45,11 @@
                             {{if index '| '}}{{provider.name}}
                         {{/each}}
                     </span>
-                    {{#if result.date_modified}} {{! moment-format will use current time if null}}
-                        <span>{{moment-format result.date_modified "MMMM YYYY"}}</span>
-                    {{/if}}
+                    <span class="pull-right">
+                        {{#if result.date_modified}} {{! moment-format will use current time if null}}
+                            <span>{{moment-format result.date_modified "MMMM YYYY"}}</span>
+                        {{/if}}
+                    </span>
                 </div>
 
 

--- a/app/templates/content.hbs
+++ b/app/templates/content.hbs
@@ -4,7 +4,7 @@
             <h1 class="p-b-md">{{model.title}}</h1>
             <h5 class="view-authors">
                 {{#each model.contributors as |author index| ~}}
-                    {{~if index ', ' ''}}<a href={{author.users.profileURL}}>{{author.users.fullName}}</a>
+                    {{~if index ', ' ''}}<a href={{author.users.profileURL}}>{{author.users.givenName}} {{author.users.familyName}}</a>
                 {{~/each}}
             </h5>
             <h6>Added on: {{moment-format model.date_created "MMMM DD, YYYY"}} | Last edited: {{moment-format model.date_modified "MMMM DD, YYYY"}} </h6>


### PR DESCRIPTION
# Purpose
1. Improve search result display on `/discover` page
2. Change authors to display with `first Last` consistently across pages- don't use different fields or different orders
3. Right align date on search results for now. I'll defer visual tweaks to @caneruguz 's talents.


![screen shot 2016-08-27 at 7 37 19 pm](https://cloud.githubusercontent.com/assets/2957073/18030699/717b0ad0-6c8e-11e6-8bbd-070fdb75a56e.png)


# Changes
- Change how author names are displayed. Where possible, use `firstName lastName` format in place of `fullName` or `last, first`.
  - The `fullName` field in the OSF is intended for profile display; individual name fields are intended to provide more fine-grained control over how name is shown.



# Tracking
https://trello.com/c/6fD8lRQ6/60-improve-layout-of-search-results

# Spec
 Formatting of the preprint summaries could be refined. 

 - ~~Top-left alignment for title~~ (seems to already be like this?)
 - [x] Move date down to bottom-right alignment
 - [ ] Source (OSF or SSRN or ARXIV) aligned right Right above or below date (will check with @caneruguz on preferred styling)
 - ? No commas after names if the “|” is also there (not sure what this is asking for?)
 - ? No space before comma in list of tags
 - [ ] Tighter in vertical space on top and bottom with the expand arrow being closer to the bottom row of text
