### PR TITLE
View page file download button should match the file picker

### DIFF
--- a/app/components/supplementary-file-browser.js
+++ b/app/components/supplementary-file-browser.js
@@ -6,6 +6,13 @@ export default Ember.Component.extend({
     scrollAnim: '',
     numShowing: 6,
     selectedFile: null,
+
+    /**
+     * An action that must be passed in. Informs parent page that a file was selected.
+     * @property chooseFile
+     */
+    chooseFile: null,
+
     // TODO Actually implement pagination
     showRightArrow: Ember.computed('numShowing', 'startValue', function() {
         return (this.get('startValue') + this.get('numShowing') < this.get('files').length);
@@ -55,6 +62,10 @@ export default Ember.Component.extend({
         },
         changeFile(file) {
             this.set('selectedFile', file);
+
+            if (this.attrs.selectFile) {
+                this.sendAction('chooseFile', file);
+            }
         },
     },
 });

--- a/app/components/supplementary-file-browser.js
+++ b/app/components/supplementary-file-browser.js
@@ -63,7 +63,7 @@ export default Ember.Component.extend({
         changeFile(file) {
             this.set('selectedFile', file);
 
-            if (this.attrs.selectFile) {
+            if (this.attrs.chooseFile) {
                 this.sendAction('chooseFile', file);
             }
         },

--- a/app/controllers/content.js
+++ b/app/controllers/content.js
@@ -3,12 +3,19 @@ import Ember from 'ember';
 export default Ember.Controller.extend({
     fullScreenMFR: false,
     expandedAuthors: true,
+
+    // The currently selected file (defaults to primary)
+    activeFile: Ember.computed.alias('model.primaryFile'),
+
     actions: {
         expandMFR() {
             this.toggleProperty('fullScreenMFR');
         },
         expandAuthors() {
             this.toggleProperty('expandedAuthors');
+        },
+        chooseFile(fileItem) {
+            this.set('activeFile', fileItem);
         }
     },
 });

--- a/app/controllers/content.js
+++ b/app/controllers/content.js
@@ -5,7 +5,7 @@ export default Ember.Controller.extend({
     expandedAuthors: true,
 
     // The currently selected file (defaults to primary)
-    activeFile: Ember.computed.alias('model.primaryFile'),
+    activeFile: Ember.computed.oneWay('model.primaryFile'),
 
     actions: {
         expandMFR() {

--- a/app/templates/content.hbs
+++ b/app/templates/content.hbs
@@ -13,7 +13,7 @@
     <div id="view-page" class="container">{{!CONTAINER DIV}}
         <div class="row p-md"> {{!CONTENT ROW}}
             <div id="mfr-col" class="col-md-{{if fullScreenMFR '12' '7'}}"> {{!LEFT COL DIV}}
-                {{supplementary-file-browser preprint=model projectURL=model.links.html}}
+                {{supplementary-file-browser preprint=model projectURL=model.links.html chooseFile=(action 'chooseFile')}}
                 <button class="expand-mfr-carrot" {{action 'expandMFR'}}>
                     <i class="fa fa-chevron-{{if fullScreenMFR 'left' 'right'}}"></i>
                 </button>
@@ -21,7 +21,7 @@
             {{#unless fullScreenMFR}}
                 <div class="col-md-5"> {{!RIGHT SIDE COL}}
                     <div class="p-sm osf-box-lt" id="download_project">{{!SHARE ROW}}
-                        <a type="button" class="btn btn-primary" href={{model.primaryFile.links.download}}>Download</a>
+                        <a class="btn btn-primary" href={{activeFile.links.download}}>Download</a>
                         <span class="p-sm pull-right">
                             <p class="f-w-lg">
                                 {{!-- Disable until share/edit functionality is available


### PR DESCRIPTION
# Purpose
Let download button on preprint view page provide the correct download link for the file currently selected in the file picker.

![screen shot 2016-08-27 at 8 50 18 pm](https://cloud.githubusercontent.com/assets/2957073/18030909/e7d34da6-6c97-11e6-8b4c-f3585a2fa4fd.png)


https://trello.com/c/SkGOyIWO/93-download-button-should-download-the-currently-selected-file