### PR TITLE
Fix typo

### DIFF
--- a/app/templates/components/search-result.hbs
+++ b/app/templates/components/search-result.hbs
@@ -62,8 +62,8 @@
                             {{/each}}
                         </div>
                     {{/if}}
-                    {{!Released on}}
-                    <div class="m-t-sm"> Released on: {{moment-format result.date_created}} </div>
+                    {{!Added on}}
+                    <div class="m-t-sm"> Added on: {{moment-format result.date_created}} </div>
                 {{/if}}
 
             </div>


### PR DESCRIPTION
`Released` -> `Added`

https://trello.com/c/CPSqKDMC/101-search-results-have-released-date-should-be-date-added