### PR TITLE
Update Taxonomy model

### DIFF
--- a/app/models/taxonomy.js
+++ b/app/models/taxonomy.js
@@ -15,6 +15,5 @@ import OsfModel from 'ember-osf/models/osf-model';
 export default OsfModel.extend({
     type: DS.attr('string'),
     text: DS.attr('string'),
-    // TODO: Api implements this as a list field for now. This should be a relationship field in the future, when API supports it
-    parentIds: DS.attr(),
+    parents: DS.attr(),
 });

--- a/app/models/taxonomy.js
+++ b/app/models/taxonomy.js
@@ -13,7 +13,6 @@ import OsfModel from 'ember-osf/models/osf-model';
  * @class Taxonomy
  */
 export default OsfModel.extend({
-    type: DS.attr('string'),
     text: DS.attr('string'),
     parents: DS.attr(),
 });


### PR DESCRIPTION
This was changed in the OSF/APIv2 in https://github.com/CenterForOpenScience/osf.io/pull/6178 (see [class definition](https://github.com/CenterForOpenScience/osf.io/pull/6178/files#diff-a85760ce1808ddd67ece5978b7a52534L11)), but seems to have not been used here. Updated anyway.

Before:
![screen shot 2016-08-27 at 23 40 43](https://cloud.githubusercontent.com/assets/5659262/18031457/c1c56046-6caf-11e6-97dd-f197b35aeb25.png)
After:
![screen shot 2016-08-27 at 23 39 06](https://cloud.githubusercontent.com/assets/5659262/18031458/c9c2623a-6caf-11e6-8d59-99ff089efc6d.png)
