### PR TITLE
Only display carrots when there are children

### DIFF
--- a/app/components/taxonomy-tree.js
+++ b/app/components/taxonomy-tree.js
@@ -14,7 +14,8 @@ export default Ember.Component.extend({
                 id: result.id,
                 text: result.get('text'),
                 children: [],
-                showChildren: false
+                showChildren: false,
+                childCount: result.get('child_count')
             });
         });
         return parsed.sort((prev, next) => {

--- a/app/models/taxonomy.js
+++ b/app/models/taxonomy.js
@@ -14,5 +14,7 @@ import OsfModel from 'ember-osf/models/osf-model';
  */
 export default OsfModel.extend({
     text: DS.attr('string'),
+    // TODO: Api implements this as a list field for now. This should be a relationship field in the future, when API supports it
+    child_count: DS.attr()
     parents: DS.attr(),
 });

--- a/app/templates/components/taxonomy-tree.hbs
+++ b/app/templates/components/taxonomy-tree.hbs
@@ -13,9 +13,11 @@
             <ul>
                 {{#each item.children as |child|}}
                     <li>
+                        {{# if child.childCount }}
                         <span class="pointer m-r-xs" {{action 'expand' child}}>
                             <i style="vertical-align: top; padding-top: 4px" class="fa {{if child.showChildren 'fa-caret-down' 'fa-caret-right'}}"></i>
                         </span>
+                        {{/if}}
                         <label style="max-width: 85%; word-wrap: break-word;">
                             <input type="checkbox" checked="{{if (if-filter child.text subjects) 'checked'}}" onclick={{action 'select' child}}>
                             {{child.text}}

--- a/app/templates/components/taxonomy-tree.hbs
+++ b/app/templates/components/taxonomy-tree.hbs
@@ -1,7 +1,7 @@
 <ul>
     {{#each topLevelItem as |item|}}
         <li>
-            <span class="pointer m-r-xs" {{action 'expand' item}}>
+            <span class="pointer m-r-xs" {{action 'expand' item}} style="{{if item.showChildren 'margin-right:2px;'}}">
                 <i style="vertical-align: top; padding-top: 4px" class="fa {{if item.showChildren 'fa-caret-down' 'fa-caret-right'}}"></i>
             </span>
             <label style="max-width: 85%; word-wrap: break-word;">
@@ -14,9 +14,11 @@
                 {{#each item.children as |child|}}
                     <li>
                         {{# if child.childCount }}
-                        <span class="pointer m-r-xs" {{action 'expand' child}}>
-                            <i style="vertical-align: top; padding-top: 4px" class="fa {{if child.showChildren 'fa-caret-down' 'fa-caret-right'}}"></i>
+                        <span class="pointer m-r-xs" {{action 'expand' child}} style="{{if child.showChildren 'margin-right:2px;'}}">
+                            <i style="vertical-align: top; padding-top: 4px;" class="fa {{if child.showChildren 'fa-caret-down' 'fa-caret-right'}}"></i>
                         </span>
+                        {{else}}
+                            <span style="padding-right: 14px"></span>
                         {{/if}}
                         <label style="max-width: 85%; word-wrap: break-word;">
                             <input type="checkbox" checked="{{if (if-filter child.text subjects) 'checked'}}" onclick={{action 'select' child}}>
@@ -24,7 +26,7 @@
                         </label>
                     </li>
                     {{#if child.showChildren}}
-                        <ul>
+                        <ul style="padding-left:40px">
                             {{#each child.children as |grandkid|}}
                                 <li>
                                     <label style="max-width: 85%; word-wrap: break-word;">


### PR DESCRIPTION
## depends on https://github.com/CenterForOpenScience/osf.io/pull/6238

carats now only appear when there is a 3rd row of taxonomy

### before
![screen shot 2016-08-28 at 8 57 52 pm](https://cloud.githubusercontent.com/assets/801594/18038176/5ac2f6ac-6d62-11e6-84d2-dfc7f5533063.png)


### after
![screen shot 2016-08-28 at 8 58 59 pm](https://cloud.githubusercontent.com/assets/801594/18038175/58269ff2-6d62-11e6-83a1-601bd6494d8b.png)


### ticket 
https://trello.com/c/GETV8yQ1/111-preprints-discover-the-caret-does-no-action