### PR TITLE
If the article author provides a DOI, show it on the view page

### DIFF
--- a/app/templates/content.hbs
+++ b/app/templates/content.hbs
@@ -36,6 +36,14 @@
                         <h3 class="p-v-md">Abstract</h3>
                         <p class="abstract">{{model.abstract}}</p>
                     </div>
+
+                    {{#if model.doi}}
+                        <div class="f-w-xs m-b-xl p-t-xs">
+                            <h3 class="p-v-md">DOI</h3>
+                            <a href="https://dx.doi.org/{{model.doi}}">{{model.doi}}</a>
+                        </div>
+                    {{/if}}
+
                     <div class="f-w-xs m-b-xl p-t-xs">
                         <h3 class="p-v-md">Subjects</h3>
                         {{#each model.subjects as |subject|}}


### PR DESCRIPTION
1. Show the DOI on the article page if a DOI is provided
2. Link to the article via the crossref DOI resolver service

Article with DOI:
![screen shot 2016-08-28 at 10 37 04 pm](https://cloud.githubusercontent.com/assets/2957073/18039477/681ea8f0-6d71-11e6-89b7-4367ed7e16bb.png)

Article without a DOI:
![screen shot 2016-08-28 at 10 38 41 pm](https://cloud.githubusercontent.com/assets/2957073/18039476/681b9534-6d71-11e6-97d0-cc936734c465.png)
