### PR TITLE
Update pinned ember-osf version --> footer changes

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "ember-font-awesome": "2.1.1",
     "ember-get-config": "0.0.4",
     "ember-load-initializers": "^0.5.1",
-    "ember-osf": "git+https://github.com/CenterForOpenScience/ember-osf.git#75f1510cf36f17553a465cfb0a19e15a4c661ca2",
+    "ember-osf": "git+https://github.com/CenterForOpenScience/ember-osf.git#043c02d1b04fd4e8ca6391887d257e63c12d9560",
     "ember-power-select": "1.0.0-beta.7",
     "ember-read-more": "0.0.13",
     "ember-resolver": "^2.0.3",


### PR DESCRIPTION
Update pinned install version of ember-osf dependency to use newest footer changes:
 https://github.com/CenterForOpenScience/ember-osf/commit/043c02d1b04fd4e8ca6391887d257e63c12d9560


Trello card:
https://trello.com/c/K0uz5PEg/5-footers-don-t-match