### PR TITLE
Feature/Pass in reordered contributor list to ember-osf method

### DIFF
--- a/app/components/preprint-form-authors.js
+++ b/app/components/preprint-form-authors.js
@@ -132,7 +132,7 @@ export default CpPanelBodyComponent.extend({
             var originalOrder = this.get('contributors');
             this.set('contributors', itemModels);
             var newIndex = itemModels.indexOf(draggedContrib);
-            this.attrs.reorderContributors(draggedContrib, newIndex).then(() => {
+            this.attrs.reorderContributors(draggedContrib, newIndex, itemModels).then(() => {
                 this.highlightSuccessOrFailure(draggedContrib.id, this, 'success');
             }, () => {
                 this.highlightSuccessOrFailure(draggedContrib.id, this, 'error');


### PR DESCRIPTION
Dependent on https://github.com/CenterForOpenScience/ember-osf/pull/129
# Purpose

Needed for reordering contributors https://trello.com/c/Du2ygimQ/108-order-of-authors-on-view-page-not-consistent-with-what-was-saved-and-what-appears-on-project

This passes in reordered contributor list to ember-osf method.  Ember-osf reorderContributors method manually updates indices of contributors in store to match order in passed in contrib list.