### PR TITLE
Change page size

### DIFF
--- a/app/components/taxonomy-tree.js
+++ b/app/components/taxonomy-tree.js
@@ -1,8 +1,6 @@
 import Ember from 'ember';
 
-//currently using the max page size our api allows, to not have to paginate. This
-// (should, test incoming) get all children of any given subject
-var pageSize = 100;
+var pageSize = 150;
 
 export default Ember.Component.extend({
     store: Ember.inject.service(),


### PR DESCRIPTION
New taxonomy items might have more than 100 children. This, together with the osf PR (https://github.com/CenterForOpenScience/osf.io/pull/6245) will allow us to grab it all.