### PR TITLE
Feature/Two columns of advisors on index page

### DIFF
--- a/app/templates/index.hbs
+++ b/app/templates/index.hbs
@@ -85,13 +85,19 @@
                 <div class="col-xs-12">
                     <h2>Advisory Group</h2>
                     <p class="m-b-lg"> Our advisory group includes leaders in preprints and scholarly communication</p>
+                </div>
+                 <div class="col-xs-6">
+                        <ul>
+                            <li><b>Devin Berg :</b> engrXiv, University of Wisconsin-Stout</li>
+                            <li><b>Pete Binfield :</b> PeerJ PrePrints</li>
+                            <li><b>Philip Cohen :</b> SocArXiv, University of Maryland</li>
+                            <li><b>Kathleen Fitzpatrick :</b> Modern Language Association</li>
+                            <li><b>John Inglis :</b> bioRxiv, Cold Spring Harbor Laboratory Press</li>
+                            <li><b>Rebecca Kennison :</b> K|N Consultants</li>
+                        </ul>
+                </div>
+                <div class="col-xs-6">
                     <ul>
-                        <li><b>Devin Berg :</b> engrXiv, University of Wisconsin-Stout</li>
-                        <li><b>Pete Binfield :</b> PeerJ PrePrints</li>
-                        <li><b>Philip Cohen :</b> SocArXiv, University of Maryland</li>
-                        <li><b>Kathleen Fitzpatrick :</b> Modern Language Association</li>
-                        <li><b>John Inglis :</b> bioRxiv, Cold Spring Harbor Laboratory Press</li>
-                        <li><b>Rebecca Kennison :</b> K|N Consultants</li>
                         <li><b>Bethany Nowviskie :</b> Digital Library Federation, University of Virginia</li>
                         <li><b>Kristen Ratan :</b> CoKo Foundation</li>
                         <li><b>Oya Rieger :</b> arXiv, Cornell University</li>


### PR DESCRIPTION
- [x] https://trello.com/c/WMZuep3b/140-landing-page-advisors-label-move-to-two-columns-of-names-for-less-vertical-space