### PR TITLE
Fix Relationship Validation [OSF-6969]

### DIFF
--- a/app/serializers/preprint.js
+++ b/app/serializers/preprint.js
@@ -8,7 +8,7 @@ export default OsfSerializer.extend({
             primary_file: {
                 data: {
                     id: snapshot.belongsTo('primaryFile', { id: true }),
-                    type: 'file'
+                    type: 'primary_file'
                 }
             }
         };


### PR DESCRIPTION
#### Purpose
- Fixes failing relationship validation for preprint payload.
- Changes the `primary_file` relationship type to match the `primary_file` relationship key. 

#### Ticket
- Relates to [OSF-6969](https://openscience.atlassian.net/browse/OSF-6969)