### PR TITLE
Don't preserve state across page loads [Trello]

### DIFF
--- a/app/controllers/discover.js
+++ b/app/controllers/discover.js
@@ -30,8 +30,8 @@ export default Ember.Controller.extend({
     osfProviders: ['OSF', 'PsyArXiv', 'SocArXiv', 'engrXiv'],
 
     // Parameters tracked on the controller; default values set in `manualResetController` method
+    facetFilters: null,
     activeFilters: null,
-
     sortByOptions: null,
     numberOfResults: 0,
     showActiveFilters: null, //should always have a provider, don't want to mix osfProviders and non-osf
@@ -55,8 +55,24 @@ export default Ember.Controller.extend({
 
     searchUrl: config.SHARE.searchUrl,
 
-    init() {
-        this._super(...arguments);
+    manualResetController() {
+        // Ember controllers are singletons; provide a method that can be called by `route#setupController` in each page view
+        // This sets defaults for any properties that should be cleared on page load
+
+        //TODO: Do query params get cleared on new page visit?
+        this.setProperties({
+            loading: false,
+            activeFilters: { providers: [], subjects: [] },
+            numberOfResults: 0,
+            queryBody: {},
+            sortByOptions: ['Relevance', 'Upload date (oldest to newest)', 'Upload date (newest to oldest)'],
+            showActiveFilters: true,
+            providersPassed: false,
+            results: Ember.ArrayProxy.create({ content: [] }),
+            expandedOSFProviders: false,
+        });
+
+        // Populate filters for page
         this.set('facetFilters', Ember.Object.create());
         Ember.$.ajax({
             type: 'POST',
@@ -79,24 +95,6 @@ export default Ember.Controller.extend({
             this.notifyPropertyChange('otherProviders');
         });
         this.loadPage();
-    },
-
-    manualResetController() {
-        // Ember controllers are singletons; provide a method that can be called by `route#setupController` in each page view
-        // This sets defaults for any properties that should be cleared on page load
-
-        //TODO: Do query params get cleared on new page visit?
-        this.setProperties({
-            loading: false,
-            activeFilters: { providers: [], subjects: [] },
-            numberOfResults: 0,
-            queryBody: {},
-            sortByOptions: ['Relevance', 'Upload date (oldest to newest)', 'Upload date (newest to oldest)'],
-            showActiveFilters: true,
-            providersPassed: false,
-            results: Ember.ArrayProxy.create({ content: [] }),
-            expandedOSFProviders: false,
-        });
     },
 
     otherProvidersLoaded: Ember.observer('otherProviders', function() {

--- a/app/controllers/discover.js
+++ b/app/controllers/discover.js
@@ -91,7 +91,7 @@ export default Ember.Controller.extend({
                     providers.push(each);
                 }
             });
-            this.set('otherProviders', providers.sort((a, b) => a < b ? 1 : -1).sort(a => a === 'Open Science Framework' ? -1 : 1));
+            this.set('otherProviders', providers.sort((a, b) => a.toLowerCase() < b.toLowerCase() ? 1 : -1).sort(a => a === 'OSF' ? -1 : 1));
             this.notifyPropertyChange('otherProviders');
         });
         this.loadPage();

--- a/app/controllers/submit.js
+++ b/app/controllers/submit.js
@@ -88,7 +88,7 @@ export default Ember.Controller.extend(BasicsValidations, NodeActionsMixin, Tagg
     authorsSaveState: false,
     disciplineSaveState: false,
 
-    clearFields() {
+    manualResetController() {
         this.get('panelActions').open('Upload');
         this.get('panelActions').close('Submit');
 
@@ -117,9 +117,7 @@ export default Ember.Controller.extend(BasicsValidations, NodeActionsMixin, Tagg
         }));
     },
 
-    hasFile: function() {
-        return this.get('file') != null;
-    }.property('file'),
+    hasFile: Ember.computed.notEmpty('file'),
 
     ///////////////////////////////////////
     // Validation rules for form sections

--- a/app/routes/discover.js
+++ b/app/routes/discover.js
@@ -2,6 +2,11 @@ import Ember from 'ember';
 import ResetScrollMixin from '../mixins/reset-scroll';
 
 export default Ember.Route.extend(ResetScrollMixin, {
+    // Ember controllers are singletons; provide a method that can be called by `route#setupController` in each page view
 
+    setupController(controller, model) {
+        controller.manualResetController();
+        this._super(controller, model);
+    }
 });
 

--- a/app/routes/submit.js
+++ b/app/routes/submit.js
@@ -13,8 +13,7 @@ export default Ember.Route.extend(ResetScrollMixin, CasAuthenticatedRouteMixin, 
         });
     },
     setupController(controller) {
-        if (controller.get('model.isLoaded'))
-            controller.clearFields();
+        controller.manualResetController();
 
         // Fetch values required to operate the page: user and userNodes
         this.get('currentUser').load()


### PR DESCRIPTION
# Ticket

https://trello.com/c/cXY0EInK/141-search-is-not-cleared-when-navigated-to-via-an-internal-link-e-g-search-nav
# Purpose

Fix issue where search page was remembering filter and subject selections from a previous visit. (when navigating via links from within ember)
# Summary of changes

Since controllers are singletons, a state-reset method needs to be defined and called on each page load.
# Side effects

Since query params are based on filters, and filters are reset on page load, this causes the back button to not remember state. (eg it resets to a generic search, even though query params ostensibly track what to load)

Long term this page will need some internal refactoring for how data is fetched, but that's a post-MVP change. This PR simply ensures that search and submit pages are reset on every visit.
## How to test this
### Search page
1. Go to search page. Select two providers and two subjects. Change search result sort order. 
2. On the project navbar, click "Add a preprint". 
3. From the /submit page, on the navbar again, click "Search" to return to the search page. The search filters should be reset to their defaults.
### Submit page

General workflows: make sure that once a preprint is started, the page completely reloads on next visit to the submit page. (and does not remember a previous preprint, node, etc)
# TODO
- [x] Reset method for search page (and ensure it's called before view)
- [x] Reset method for content page (and ensure it's called before view)
- [x] Vet uses of not-so-clever bindings, like `computed.oneWay` for content page controller
