### PR TITLE
Hotfix/Prevent creating multiple nodes in preprint process

### DIFF
--- a/app/components/file-uploader.js
+++ b/app/components/file-uploader.js
@@ -25,6 +25,7 @@ export default Ember.Component.extend(TitleValidation, {
     callback: null,
     nodeTitle: null,
     createChild: false,
+    uploadInProgress: false,
 
     dropzoneOptions: {
         maxFiles: 1,
@@ -59,6 +60,7 @@ export default Ember.Component.extend(TitleValidation, {
         },
 
         createProjectAndUploadFile() {
+            this.set('uploadInProgress', true);
             this.get('store').createRecord('node', {
                 public: false, // ?
                 category: 'project',

--- a/app/templates/components/file-uploader.hbs
+++ b/app/templates/components/file-uploader.hbs
@@ -16,5 +16,5 @@
 {{/liquid-if}}
 
 <div class="p-t-xs pull-right">
-    <button class="btn btn-primary" disabled={{not (and hasFile titleValid)}} {{action 'createProjectAndUploadFile'}}>Next</button>
+    <button class="btn btn-primary" disabled={{not (and (not uploadInProgress)(and hasFile titleValid))}} {{action 'createProjectAndUploadFile'}}>Next</button>
 </div>


### PR DESCRIPTION
# Purpose

User could upload file and click "next" multiple times before file upload was complete.  Multiple nodes would then be created in that process, and the file would not have been uploaded to the node that was set on the preprint.  Creating a preprint would then fail.

# Changes

As soon as 'next' is pushed and the node creation/file upload step starts, the 'next' button is disabled.
