### PR TITLE
[WIP] Support OSF commenting functionality in preprints

### DIFF
--- a/app/controllers/content.js
+++ b/app/controllers/content.js
@@ -1,7 +1,9 @@
 import Ember from 'ember';
-import loadAll from 'ember-osf/utils/load-relationship';
 
-export default Ember.Controller.extend({
+import loadAll from 'ember-osf/utils/load-relationship';
+import CommentableMixin from 'ember-osf/mixins/commentable';
+
+export default Ember.Controller.extend(CommentableMixin, {
     fullScreenMFR: false,
     expandedAuthors: true,
 

--- a/app/models/preprint.js
+++ b/app/models/preprint.js
@@ -19,11 +19,14 @@ export default OsfModel.extend({
     title: DS.attr('string'),
     // TODO: May be a relationship in the future pending APIv2 changes
     subjects: DS.attr(),
-    date_created: DS.attr('date'),
+    date_created: DS.attr('date'),  // TODO: Check capitalization?
     date_modified: DS.attr('date'),
     abstract: DS.attr('string'),
     tags: DS.attr(),
     doi: DS.attr('string'),
+
+    currentUserCanComment: DS.attr('boolean'),
+    currentUserPermissions: DS.attr('string'),
 
     // Relationships
     primaryFile: DS.belongsTo('file', { inverse: null }),

--- a/app/models/preprint.js
+++ b/app/models/preprint.js
@@ -27,6 +27,8 @@ export default OsfModel.extend({
 
     // Relationships
     primaryFile: DS.belongsTo('file', { inverse: null }),
+    comments: DS.hasMany('comments'),
+
     files: DS.hasMany('file-providers', { inverse: null }),
     providers: DS.hasMany('preprint-provider', { inverse: 'preprints', async: true }),
 

--- a/app/templates/content.hbs
+++ b/app/templates/content.hbs
@@ -78,5 +78,18 @@
                 </div> {{!END RIGHT SIDE COL}}
             {{/unless}}
         </div> {{!END CONTENT ROW}}
+        <div class="row">
+            <div class="col-md-12">
+                {{comment-pane
+                  comments=comments
+                  title=model.title
+                  resource=model
+                  addComment=(action 'addComment')
+                  editComment=(action 'editComment')
+                  deleteComment=(action 'deleteComment')
+                  restoreComment=(action 'restoreComment')
+                  reportComment=(action 'reportComment')}}
+            </div>
+        </div>
     </div>{{!END DIV CONTAINER}}
 </div>


### PR DESCRIPTION
❗ This PR depends on, and should be merged with:
- OSF: https://github.com/CenterForOpenScience/osf.io/pull/6258
- Ember-OSF: https://github.com/CenterForOpenScience/ember-osf/pull/103

Those PRs may not be ready for individual merge immediately. Ember-OSF support for comments currently lags behind the OSF implementation in several ways. (see related ticket for status)

# Purpose
Demonstrate adding support for OSF commenting functionality to a preprint-specific view page.

![screen shot 2016-08-31 at 4 10 48 pm](https://cloud.githubusercontent.com/assets/2957073/18144673/bf63c64c-6f95-11e6-8c82-d0474357676e.png)


# Summary of changes
- Add an ember-osf comments widget to the preprints page

# Notes for reviewers
⚠️ Rather than add a new OSF endpoint, this uses the existing nodes endpoint for preprints. If we change how preprints are represented in the future, we should also change how the ember-osf functionality works.

# Ticket
https://openscience.atlassian.net/browse/PREP-135