### PR TITLE
Fix search result links by separating hyperlinks [PREP-152] 

### DIFF
--- a/app/controllers/discover.js
+++ b/app/controllers/discover.js
@@ -136,9 +136,22 @@ export default Ember.Controller.extend({
                     subjects: hit._source.subjects.map(each => ({text: each})),
                     providers: hit._source.sources.map(item => ({name: item})),
                     osfProvider: hit._source.sources.reduce((acc, source) => (acc || this.get('osfProviders').indexOf(source) !== -1), false),
+                    hyperLinks : [ // Links that are hyperlinks from hit._source.lists.links
+                        {
+                            type: 'share',
+                            url: config.SHARE.baseUrl + 'curate/preprint/' + hit._id
+                        }
+                    ],
+                    infoLinks : [] // Links that are not hyperlinks  hit._source.lists.links
                 });
 
-                result.shareLink = config.SHARE.baseUrl + 'curate/preprint/' + result.id;
+                hit._source.lists.links.forEach(function(linkItem){
+                    if(isHyperLink(linkItem.url)){
+                        result.hyperLinks.push(linkItem);
+                    } else {
+                        result.infoLinks.push(linkItem);
+                    }
+                });
 
                 result.contributors = result.lists.contributors.map(contributor => ({
                     users: Object.keys(contributor).reduce((acc, key) => Ember.merge(acc, {[key.camelize()]: contributor[key]}), {})

--- a/app/controllers/discover.js
+++ b/app/controllers/discover.js
@@ -9,15 +9,15 @@ var filterMap = {
 };
 
 // Regex for checking url from osf repo website/static/js/profile.js
-var urlRule =  '^(https?:\\/\\/)?'+ // protocol
-           '((([a-z\\d]([a-z\\d-]*[a-z\\d])*)\\.)+[a-z]{2,}|'+ // domain name
-           '((\\d{1,3}\\.){3}\\d{1,3}))'+ // OR ip (v4) address
-           '(\\:\\d+)?(\\/[-a-z\\d%_.~+]*)*'+ // port and path
-           '(\\?[;&a-z\\d%_.~+=-]*)?'+ // query string
+var urlRule = '^(https?:\\/\\/)?' + // protocol
+           '((([a-z\\d]([a-z\\d-]*[a-z\\d])*)\\.)+[a-z]{2,}|' + // domain name
+           '((\\d{1,3}\\.){3}\\d{1,3}))' + // OR ip (v4) address
+           '(\\:\\d+)?(\\/[-a-z\\d%_.~+]*)*' + // port and path
+           '(\\?[;&a-z\\d%_.~+=-]*)?' + // query string
            '(\\#[-a-z\\d_]*)?$';
 
-function isHyperLink (link) {
-    var urlexp = new RegExp(urlRule,'i');
+function isHyperLink(link) {
+    var urlexp = new RegExp(urlRule, 'i');
     return urlexp.test(link);
 }
 
@@ -136,17 +136,17 @@ export default Ember.Controller.extend({
                     subjects: hit._source.subjects.map(each => ({text: each})),
                     providers: hit._source.sources.map(item => ({name: item})),
                     osfProvider: hit._source.sources.reduce((acc, source) => (acc || this.get('osfProviders').indexOf(source) !== -1), false),
-                    hyperLinks : [ // Links that are hyperlinks from hit._source.lists.links
+                    hyperLinks: [// Links that are hyperlinks from hit._source.lists.links
                         {
                             type: 'share',
                             url: config.SHARE.baseUrl + 'curate/preprint/' + hit._id
                         }
                     ],
-                    infoLinks : [] // Links that are not hyperlinks  hit._source.lists.links
+                    infoLinks: [] // Links that are not hyperlinks  hit._source.lists.links
                 });
 
-                hit._source.lists.links.forEach(function(linkItem){
-                    if(isHyperLink(linkItem.url)){
+                hit._source.lists.links.forEach(function(linkItem) {
+                    if (isHyperLink(linkItem.url)) {
                         result.hyperLinks.push(linkItem);
                     } else {
                         result.infoLinks.push(linkItem);

--- a/app/controllers/discover.js
+++ b/app/controllers/discover.js
@@ -8,6 +8,19 @@ var filterMap = {
     subjects: 'subjects.raw'
 };
 
+// Regex for checking url from osf repo website/static/js/profile.js
+var urlRule =  '^(https?:\\/\\/)?'+ // protocol
+           '((([a-z\\d]([a-z\\d-]*[a-z\\d])*)\\.)+[a-z]{2,}|'+ // domain name
+           '((\\d{1,3}\\.){3}\\d{1,3}))'+ // OR ip (v4) address
+           '(\\:\\d+)?(\\/[-a-z\\d%_.~+]*)*'+ // port and path
+           '(\\?[;&a-z\\d%_.~+=-]*)?'+ // query string
+           '(\\#[-a-z\\d_]*)?$';
+
+function isHyperLink (link) {
+    var urlexp = new RegExp(urlRule,'i');
+    return urlexp.test(link);
+}
+
 export default Ember.Controller.extend({
     // TODO: either remove or add functionality to info icon on "Refine your search panel"
 

--- a/app/styles/app.scss
+++ b/app/styles/app.scss
@@ -249,11 +249,7 @@ ul.preprints-block-list {
     display: block;
     list-style: none;
     padding-left: 0;
-    li {
-
-    }
 }
-
 
 
 /* VIEW page */

--- a/app/styles/app.scss
+++ b/app/styles/app.scss
@@ -217,6 +217,11 @@ ul.comma-list {
         word-wrap: break-word;
         word-break: break-word;
         overflow-wrap: break-word;
+        box-shadow : 0 1px 2px #ddd;
+        border: none;
+        h4 {
+            font-weight: normal;
+        }
     }
 }
 

--- a/app/styles/app.scss
+++ b/app/styles/app.scss
@@ -240,6 +240,14 @@ ul.comma-list {
 .search-result-providers {
     font-weight: bold;
 }
+ul.preprints-block-list {
+    display: block;
+    list-style: none;
+    padding-left: 0;
+    li {
+
+    }
+}
 
 
 

--- a/app/templates/components/search-result.hbs
+++ b/app/templates/components/search-result.hbs
@@ -58,9 +58,18 @@
                 {{#if showBody}}
                     {{!Tags}}
                     {{#if result.hyperLinks}}
-                        {{#each result.hyperLinks as |link|}}
-                            <p><a href='{{link.url}}'>{{link.url}}</a></p>
-                        {{/each}}
+                        <ul class="preprints-block-list m-t-sm">
+                            {{#each result.hyperLinks as |link|}}
+                                <li><a href='{{link.url}}'>{{link.url}}</a></li>
+                            {{/each}}
+                        </ul>
+                    {{/if}}
+                    {{#if result.infoLinks}}
+                        <ul class="preprints-block-list">
+                            {{#each result.infoLinks as |link|}}
+                                <li><b>{{link.type}}:</b> {{link.url}}</li>
+                            {{/each}}
+                        </ul>
                     {{/if}}
                     {{#if result.tags}}
                         <div class="m-t-sm">

--- a/app/templates/components/search-result.hbs
+++ b/app/templates/components/search-result.hbs
@@ -57,8 +57,10 @@
 
                 {{#if showBody}}
                     {{!Tags}}
-                    {{#if result.shareLink}}
-                        <p><a href='{{result.shareLink}}'>{{result.shareLink}}</a></p>
+                    {{#if result.hyperLinks}}
+                        {{#each result.hyperLinks as |link|}}
+                            <p><a href='{{link.url}}'>{{link.url}}</a></p>
+                        {{/each}}
                     {{/if}}
                     {{#if result.tags}}
                         <div class="m-t-sm">


### PR DESCRIPTION
JIRA Ticket: https://openscience.atlassian.net/browse/PREP-152

Cleans up the view of links so hyperlinks and information links are displayed separately. 

Bonus: Slight style changes that makes the search result box look much better
- heading font weight changed to normal
- border removed, different box shadow added 
![screen shot 2016-09-01 at 3 58 28 pm](https://cloud.githubusercontent.com/assets/1314003/18182217/0068d0f2-705d-11e6-9976-4f85f80bf6ae.png)

