### PR TITLE
For not found use intermediateTransitionTo to keep the URL the same [PREP-154]

### DIFF
--- a/app/routes/404.js
+++ b/app/routes/404.js
@@ -2,6 +2,6 @@ import Ember from 'ember';
 
 export default Ember.Route.extend({
     beforeModel() {
-        this.transitionTo('page-not-found');
+        this.intermediateTransitionTo('page-not-found');
     }
 });

--- a/app/routes/content.js
+++ b/app/routes/content.js
@@ -11,7 +11,7 @@ export default Ember.Route.extend(ResetScrollMixin, {
     },
     actions: {
         error(error, transition) {
-            window.history.replaceState( {} , 'preprints', 'preprints/'+ transition.params.content.preprint_id);
+            window.history.replaceState({}, 'preprints', 'preprints/' + transition.params.content.preprint_id);
             this.intermediateTransitionTo('page-not-found');
         }
     }

--- a/app/routes/content.js
+++ b/app/routes/content.js
@@ -11,7 +11,7 @@ export default Ember.Route.extend(ResetScrollMixin, {
     },
     actions: {
         error: function() {
-            this.transitionTo('/page-not-found');
+            this.intermediateTransitionTo('/page-not-found');
         }
     }
 });

--- a/app/routes/content.js
+++ b/app/routes/content.js
@@ -10,7 +10,8 @@ export default Ember.Route.extend(ResetScrollMixin, {
         return this._super(...arguments);
     },
     actions: {
-        error: function() {
+        error(error, transition) {
+            window.history.replaceState( {} , 'preprints', 'preprints/'+ transition.params.content.preprint_id);
             this.intermediateTransitionTo('page-not-found');
         }
     }

--- a/app/routes/content.js
+++ b/app/routes/content.js
@@ -11,7 +11,7 @@ export default Ember.Route.extend(ResetScrollMixin, {
     },
     actions: {
         error: function() {
-            this.intermediateTransitionTo('/page-not-found');
+            this.intermediateTransitionTo('page-not-found');
         }
     }
 });


### PR DESCRIPTION
Use `intermediateTransitionTo` so that the URL stays the same when an invalid URL is accessed.

## Current behavior:
- Visiting a broken link from an outside source: keeps the URL that you're visiting
- Typing in a broken link: keeps the URL that you're visiting
- Visiting a broken link from **within** the application: reaches an error state from within ember, and updates the window location using a bit of a hacky method.

## Future desired behavior:
Visiting a broken link from within the application shows the URL that the link was leading to in the error bar. This is very much not straight forward to accomplish from within ember as most of the URL logic is based on models, and errors are thrown before a "bad" url is ever actually reached.  Maybe with "replaceWith" or "replaceState" - but I had no luck with that yet...
ticket for this issue: https://openscience.atlassian.net/browse/PREP-159


**this** issue ticket: https://openscience.atlassian.net/browse/PREP-154
