### PR TITLE
[rfr] Custom titles for each page of site

### DIFF
--- a/app/index.html
+++ b/app/index.html
@@ -3,7 +3,6 @@
   <head>
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
-    <title>OSF | Preprints</title>
     <meta name="description" content="">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <meta name="author" content="">

--- a/app/models/preprint.js
+++ b/app/models/preprint.js
@@ -19,8 +19,8 @@ export default OsfModel.extend({
     title: DS.attr('string'),
     // TODO: May be a relationship in the future pending APIv2 changes
     subjects: DS.attr(),
-    date_created: DS.attr('date'),
-    date_modified: DS.attr('date'),
+    dateCreated: DS.attr('date'),
+    dateModified: DS.attr('date'),
     abstract: DS.attr('string'),
     tags: DS.attr(),
     doi: DS.attr('string'),

--- a/app/templates/404.hbs
+++ b/app/templates/404.hbs
@@ -1,1 +1,3 @@
+{{title 'Page not found'}}
+
 {{outlet}}

--- a/app/templates/application.hbs
+++ b/app/templates/application.hbs
@@ -1,4 +1,4 @@
-{{title 'OSF | Preprints' separator=' | '}}
+{{title 'OSF Preprints' separator=' | '}}
 
 {{osf-navbar signupUrl=signupUrl loginAction=(action 'login') hideSearch=true}}
 {{preprint-navbar}}

--- a/app/templates/application.hbs
+++ b/app/templates/application.hbs
@@ -1,3 +1,5 @@
+{{title 'OSF | Preprints' separator=' | '}}
+
 {{osf-navbar signupUrl=signupUrl loginAction=(action 'login') hideSearch=true}}
 {{preprint-navbar}}
 

--- a/app/templates/components/search-result.hbs
+++ b/app/templates/components/search-result.hbs
@@ -48,8 +48,8 @@
                         {{/each}}
                     </span>
                     <span class="pull-right">
-                        {{#if result.date_modified}} {{! moment-format will use current time if null}}
-                            <span>{{moment-format result.date_modified "MMMM YYYY"}}</span>
+                        {{#if result.dateModified}} {{! moment-format will use current time if null}}
+                            <span>{{moment-format result.dateModified "MMMM YYYY"}}</span>
                         {{/if}}
                     </span>
                 </div>
@@ -68,7 +68,7 @@
                         </div>
                     {{/if}}
                     {{!Added on}}
-                    <div class="m-t-sm"> Added on: {{moment-format result.date_created}} </div>
+                    <div class="m-t-sm"> Added on: {{moment-format result.dateCreated}} </div>
                 {{/if}}
 
             </div>

--- a/app/templates/content.hbs
+++ b/app/templates/content.hbs
@@ -1,3 +1,5 @@
+{{title model.title}}
+
 <div id="view-page">
     <div class="p-t-xl m-t-xl p-b-md m-b-md dark-overlay-header-background header-row">{{!HEADER ROW}}
         <div class="container">{{!CONTAINER DIV}}
@@ -17,7 +19,7 @@
                     {{/if}}
                 </ul>
             </h5>
-            <h6>Added on: {{moment-format model.date_created "MMMM DD, YYYY"}} | Last edited: {{moment-format model.date_modified "MMMM DD, YYYY"}} </h6>
+            <h6>Added on:  {{moment-format model.dateCreated "MMMM DD, YYYY"}} | Last edited: {{moment-format model.dateModified "MMMM DD, YYYY"}} </h6>
         </div> {{!END CONTAINER DIV}}
     </div> {{!END HEADER ROW}}
     <div id="view-page" class="container">{{!CONTAINER DIV}}

--- a/app/templates/discover.hbs
+++ b/app/templates/discover.hbs
@@ -1,3 +1,5 @@
+{{title 'Search'}}
+
 <div class="preprint-search-header">
     <div class="container">
         <div class="row m-v-md ">

--- a/app/templates/page-not-found.hbs
+++ b/app/templates/page-not-found.hbs
@@ -1,3 +1,5 @@
+{{title 'Page not found'}}
+
 <div class="preprint-404">
     <div class="container">
         <div class="row">

--- a/app/templates/submit.hbs
+++ b/app/templates/submit.hbs
@@ -1,3 +1,5 @@
+{{title 'Submit'}}
+
 <div class="preprint-submit-header">
     <div class="container">
         <div class="row">

--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
     "ember-get-config": "0.0.4",
     "ember-load-initializers": "^0.5.1",
     "ember-osf": "git+https://github.com/CenterForOpenScience/ember-osf.git#081f433c1bb79141dc4c5e35bde9bd81c40c1069",
+    "ember-page-title": "3.0.6",
     "ember-power-select": "1.0.0-beta.7",
     "ember-read-more": "0.0.13",
     "ember-resolver": "^2.0.3",


### PR DESCRIPTION
# Ticket
https://openscience.atlassian.net/browse/PREP-119

# Purpose
Instead of every page on the site having a title of "OSF | Preprints", allow each page on the site to add its own suffix- eg `OSF Preprints | Search` or `OSF Preprints | This preprint name` .

This will improve usability in the tab bar and back button history. Addon documentation here:
http://tim-evans.github.io/ember-page-title/

(screenshot is outdated; extra separator removed. See above text example)
![screen shot 2016-09-01 at 5 17 47 pm](https://cloud.githubusercontent.com/assets/2957073/18185381/67bea318-706b-11e6-8e85-c73b6795ba03.png)


# Summary of changes
- Custom page titles
- Unrelated, but: Make date field names consistent with the capitalization used on the node model (and ember conventions)