### PR TITLE
[rfr] Index page should load even if ES is down

### DIFF
--- a/app/controllers/index.js
+++ b/app/controllers/index.js
@@ -1,0 +1,22 @@
+import Ember from 'ember';
+import config from 'ember-get-config';
+
+const getTotalPayload = '{"size": 0, "from": 0,"query": {"bool": {"must": {"query_string": {"query": "*"}}, "filter": [{"term": {"type.raw": "preprint"}}]}}}';
+
+export default Ember.Controller.extend({
+    sharePreprintsTotal: null,
+    init() {
+        // Fetch total number of preprints. Allow elasticsearch failure to pass silently.
+        // This is considered to be a one-time fetch, and therefore is run in controller init.
+        Ember.$.ajax({
+            type: 'POST',
+            url: config.SHARE.searchUrl,
+            data: getTotalPayload,
+            contentType: 'application/json',
+            crossDomain: true,
+        }).then(results => results.hits.total.toLocaleString())
+          .then(count => this.set('sharePreprintsTotal', count))
+          .fail(() => {});
+    }
+
+});

--- a/app/routes/index.js
+++ b/app/routes/index.js
@@ -1,8 +1,6 @@
 import Ember from 'ember';
-import config from 'ember-get-config';
-import ResetScrollMixin from '../mixins/reset-scroll';
 
-const getTotalPayload = '{"size": 0, "from": 0,"query": {"bool": {"must": {"query_string": {"query": "*"}}, "filter": [{"term": {"type.raw": "preprint"}}]}}}';
+import ResetScrollMixin from '../mixins/reset-scroll';
 
 export default Ember.Route.extend(ResetScrollMixin, {
     model() {
@@ -11,17 +9,6 @@ export default Ember.Route.extend(ResetScrollMixin, {
     setupController(controller, model) {
         this._super(controller, model);
         controller.set('currentDate', new Date());
-
-        // Fetch total number of preprints. Allow elasticsearch failure to pass silently.
-        Ember.$.ajax({
-            type: 'POST',
-            url: config.SHARE.searchUrl,
-            data: getTotalPayload,
-            contentType: 'application/json',
-            crossDomain: true,
-        }).then(results => results.hits.total.toLocaleString())
-          .then(count => controller.set('sharePreprintsTotal', count))
-          .fail(() => {});
     },
     actions: {
         search(q) {

--- a/app/routes/index.js
+++ b/app/routes/index.js
@@ -24,10 +24,6 @@ export default Ember.Route.extend(ResetScrollMixin, {
           .fail(() => {});
     },
     actions: {
-        // TODO: properly transfer subject to discover route
-        goToSubject(sub) {
-            this.transitionTo('discover', { queryParams: { subject: sub } });
-        },
         search(q) {
             this.transitionTo('discover', { queryParams: { queryString: q } });
         }

--- a/app/routes/index.js
+++ b/app/routes/index.js
@@ -19,8 +19,8 @@ export default Ember.Route.extend(ResetScrollMixin, {
             data: getTotalPayload,
             contentType: 'application/json',
             crossDomain: true,
-        }).done(results => results.hits.total.toLocaleString())
-          .done(count => controller.set('sharePreprintsTotal', count))
+        }).then(results => results.hits.total.toLocaleString())
+          .then(count => controller.set('sharePreprintsTotal', count))
           .fail(() => {});
     },
     actions: {

--- a/app/templates/index.hbs
+++ b/app/templates/index.hbs
@@ -14,10 +14,13 @@
                 {{!SEARCH}}
                 <div class="preprint-search col-xs-10 col-xs-offset-1 col-md-8 col-md-offset-2 m-v-lg" >
                     {{search-preprints search="search"}}
-                    <p class="p-l-md">
-                        <span class="f-w-lg">{{sharePreprintsTotal}} searchable preprints </span>
-                        <span>as of {{moment-format currentDate "MMMM DD, YYYY"}}</span>
-                    </p>
+
+                    {{#if sharePreprintsTotal}}
+                        <p class="p-l-md">
+                            <span class="f-w-lg">{{sharePreprintsTotal}} searchable preprints </span>
+                            <span>as of {{moment-format currentDate "MMMM DD, YYYY"}}</span>
+                        </p>
+                    {{/if}}
                 </div>
             </div> {{!END ROW}}
             <div class="row">

--- a/app/templates/index.hbs
+++ b/app/templates/index.hbs
@@ -15,9 +15,8 @@
                 <div class="preprint-search col-xs-10 col-xs-offset-1 col-md-8 col-md-offset-2 m-v-lg" >
                     {{search-preprints search="search"}}
                     <p class="p-l-md">
-                        <span class="f-w-lg">{{model.sharePreprintsTotal}} searchable preprints </span>
-                        <span>as of {{moment-format model.theDate "MMMM DD, YYYY"}}</span>
-
+                        <span class="f-w-lg">{{sharePreprintsTotal}} searchable preprints </span>
+                        <span>as of {{moment-format currentDate "MMMM DD, YYYY"}}</span>
                     </p>
                 </div>
             </div> {{!END ROW}}
@@ -25,7 +24,6 @@
                 <div class="text-center col-xs-12">
                     <p class="lead"> or </p>
                     {{#link-to "submit" type="button" class="btn btn-success btn-lg"}}Add a preprint{{/link-to}}
-                    {{!TODO: Needs a good example before production }}
                     <div class="m-t-md">{{#link-to 'content' 'khbvy'}}See an example {{/link-to}}</div>
 
                 </div>
@@ -40,7 +38,7 @@
                 <div class="col-xs-12">
                     <h2>Browse <small>by subject</small></h2>
                     <div class="subjectsList p-lg"> {{!SUBJECTS LIST}}
-                        {{taxonomy-top-list list=model.subjects}}
+                        {{taxonomy-top-list list=model}}
                     </div> {{!END SUBJECTS LIST}}
                 </div>
             </div>{{!END ROW}}

--- a/config/environment.js
+++ b/config/environment.js
@@ -56,6 +56,11 @@ module.exports = function(environment) {
         ENV.APP.LOG_VIEW_LOOKUPS = false;
 
         ENV.APP.rootElement = '#ember-testing';
+
+        // Don't make external requests during unit test
+        // TODO: Provide mocks for all components with manual AJAX calls in the future.
+        ENV.SHARE.baseUrl = '/nowhere';
+        ENV.SHARE.searchUrl = '/nowhere';
     }
 
     if (environment === 'production') {

--- a/tests/unit/controllers/index-test.js
+++ b/tests/unit/controllers/index-test.js
@@ -1,0 +1,12 @@
+import { moduleFor, test } from 'ember-qunit';
+
+moduleFor('controller:index', 'Unit | Controller | index', {
+    // Specify the other units that are required for this test.
+    // needs: ['controller:foo']
+});
+
+// Replace this with your real tests.
+test('it exists', function(assert) {
+    let controller = this.subject();
+    assert.ok(controller);
+});


### PR DESCRIPTION
# Ticket
https://openscience.atlassian.net/browse/PREP-151

# Purpose
Allow the preprints app to load even when ES is down. On this page, elasticsearch is used specifically for the "x searchable counts" label that appears under the search box.

Also simplify the model hook on the index page, and don't show count box at all when ES doesn't load.

When ES is running:
![screen shot 2016-09-02 at 11 32 48 am](https://cloud.githubusercontent.com/assets/2957073/18209426/b24556d4-7101-11e6-801b-87b42c1d42d6.png)


When ES is down (or inaccessible due to network etc)
![screen shot 2016-09-02 at 11 32 33 am](https://cloud.githubusercontent.com/assets/2957073/18209434/be5aae06-7101-11e6-8183-43e21ab05044.png)
