### PR TITLE
[rfr] Contributor search: support filtering on multiple fields

### DIFF
--- a/app/controllers/submit.js
+++ b/app/controllers/submit.js
@@ -272,19 +272,23 @@ export default Ember.Controller.extend(BasicsValidations, NodeActionsMixin, Tagg
             this.send('next', this.get('_names.1'));
         },
         /**
-         * findContributors method.  Queries APIv2 users endpoint on full_name.  Fetches specified page of results.
-         * TODO will eventually need to be changed to multifield query.
+         * findContributors method.  Queries APIv2 users endpoint on any of a set of name fields.  Fetches specified page of results.
          *
          * @method findContributors
          * @param {String} query ID of user that will be a contributor on the node
          * @param {Integer} page Page number of results requested
-         * @return {Record} Returns specified page of user records matching full_name query
+         * @return {User[]} Returns specified page of user records matching query
          */
         findContributors(query, page) {
-            return this.store.query('user', { filter: { full_name: query }, page: page }).then((contributors) => {
+            return this.store.query('user', {
+                filter: {
+                    'full_name,given_name,middle_names,family_name': query
+                },
+                page: page
+            }).then((contributors) => {
                 this.set('searchResults', contributors);
                 return contributors;
-            }, () => {
+            }).catch(() => {
                 this.get('toast').error('Could not perform search query.');
                 this.highlightSuccessOrFailure('author-search-box', this, 'error');
             });


### PR DESCRIPTION
# Ticket
https://openscience.atlassian.net/browse/PREP-90

# Purpose
Allow the `/submit` page "Authors -> search by name" box to search across a variety of name fields instead of just `full_name`.

See description of the multifield contributor search syntax here: https://github.com/CenterForOpenScience/osf.io/pull/6145

# How to test this
In the OSF, go to the settings page (`/settings`). Edit the profile fields so that `full_name`, `given_name`, `middle_names`, and `family_name` all have different values.

Then on the "add a preprint" (`/preprints/submit`) page, search for each of those values in turn. (taking care to search for someone else in between so that it's clear your search is doing something)

In the old search, the user would only show up if you matched the value in the full_name field. Now, a match for any of those fields will return the user, and the search result will display their `full name`.