### PR TITLE
[rfr] [as-is] Fix search page hanging when special characters present in query [PREP-160]

### DIFF
--- a/app/controllers/discover.js
+++ b/app/controllers/discover.js
@@ -1,6 +1,8 @@
 import Ember from 'ember';
 import config from 'ember-get-config';
 
+import { elasticEscape } from '../utils/elastic-query';
+
 var getProvidersPayload = '{"from": 0,"query": {"bool": {"must": {"query_string": {"query": "*"}}, "filter": [{"term": {"type.raw": "preprint"}}]}},"aggregations": {"sources": {"terms": {"field": "sources.raw","size": 200}}}}';
 
 var filterMap = {
@@ -158,7 +160,7 @@ export default Ember.Controller.extend({
         }
         let query = {
             query_string: {
-                query: this.get('queryString') || '*'
+                query: elasticEscape(this.get('queryString')) || '*'
             }
         };
 

--- a/app/utils/elastic-query.js
+++ b/app/utils/elastic-query.js
@@ -1,0 +1,23 @@
+import Ember from 'ember';
+
+/**
+ * @module ember-preprints
+ * @submodule utils
+ */
+
+/**
+ * Backslash-escape characters with special meaning to elasticsearch, to prevent queries from failing
+ *   https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-query-string-query.html#_reserved_characters
+ *
+ * @param {String} text
+ * @returns {*}
+ */
+function elasticEscape(text) {
+    if (Ember.$.type(text) === 'string') {
+        return text.replace(/[+\-=><!(){}\[\]^"~*?:\\/]|\&\&|\|\|/g, '\\$&');
+    }
+    return text;
+}
+
+export { elasticEscape };
+

--- a/tests/unit/utils/elastic-query-test.js
+++ b/tests/unit/utils/elastic-query-test.js
@@ -1,0 +1,11 @@
+import { elasticEscape } from 'preprint-service/utils/elastic-query';
+import { module, test } from 'qunit';
+
+module('Unit | Utility | elastic query');
+
+// Replace this with your real tests.
+test('common elasticsearch special characters are escaped', function(assert) {
+    let result = elasticEscape('Malformed query " && special operators + escaping & not more than needed');
+    assert.equal(result, 'Malformed query \\" \\&& special operators \\+ escaping & not more than needed',
+        'Special charcters were not correctly escaped');
+});


### PR DESCRIPTION
# Ticket
https://openscience.atlassian.net/browse/PREP-160

# Purpose
Fix an issue where certain characters with special meaning in elasticsearch were causing search page to hang. Reported multiple times on sentry post-announcement.

The root cause is that these characters could not be parsed in a query body according to this list:
https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-query-string-query.html#_reserved_characters

Essentially: ES is returning a 200 response code, and informing the user of the failed query in the payload response. This means that the search page was hanging on a failed query.

# How to test this
Go to `/discover`. Search for something with a quotation mark: `anteaters united"`. Before the fix, there should be errors in the JS console, and the spinner should be stuck on loading.

After the fix, results should be returned.

# Notes for reviewers
I haven't worked with elasticsearch extensively- so even though this stops the query from failing, I'm not 100% sure that the meaning of the special characters is being correctly translated over to the search server. 

⚠️  This is worth a closer look on those grounds; I'm putting this up as-is before heading off.