### PR TITLE
Feature: share preprint on social media

### DIFF
--- a/app/controllers/content.js
+++ b/app/controllers/content.js
@@ -5,7 +5,18 @@ export default Ember.Controller.extend({
     fullScreenMFR: false,
     expandedAuthors: true,
     expandShare: false,
-
+    twitterHref: Ember.computed('model', function() {
+        return 'https://twitter.com/intent/tweet?url=' + window.location.href + '&text=' + this.get('model.title') + '&via=OSFramework';
+    }),
+    facebookHref: Ember.computed('model', function() {
+        return 'https://www.facebook.com/sharer/sharer.php?u=' + window.location.href;
+    }),
+    linkedinHref: Ember.computed('model', function() {
+        return 'https://www.linkedin.com/cws/share?url=' + window.location.href + '&title=' + this.get('model.title');
+    }),
+    emailHref: Ember.computed('model', function() {
+        return 'mailto:?subject=' + this.get('model.title') + '&body=' + window.location.href;
+    }),
     // The currently selected file (defaults to primary)
     activeFile: null,
 
@@ -35,6 +46,11 @@ export default Ember.Controller.extend({
         },
         chooseFile(fileItem) {
             this.set('activeFile', fileItem);
+        },
+        shareLink(href) {
+            window.open(href, '', 'menubar=no,toolbar=no,resizable=yes,scrollbars=yes,width=600,height=400');
+            this.toggleProperty('expandShare');
+            return false;
         }
     },
 });

--- a/app/controllers/content.js
+++ b/app/controllers/content.js
@@ -4,6 +4,7 @@ import loadAll from 'ember-osf/utils/load-relationship';
 export default Ember.Controller.extend({
     fullScreenMFR: false,
     expandedAuthors: true,
+    expandShare: false,
 
     // The currently selected file (defaults to primary)
     activeFile: null,
@@ -23,6 +24,9 @@ export default Ember.Controller.extend({
     }),
 
     actions: {
+        toggleShare() {
+            this.toggleProperty('expandShare');
+        },
         expandMFR() {
             this.toggleProperty('fullScreenMFR');
         },

--- a/app/controllers/content.js
+++ b/app/controllers/content.js
@@ -4,7 +4,6 @@ import loadAll from 'ember-osf/utils/load-relationship';
 export default Ember.Controller.extend({
     fullScreenMFR: false,
     expandedAuthors: true,
-    expandShare: false,
     twitterHref: Ember.computed('model', function() {
         return encodeURI('https://twitter.com/intent/tweet?url=' + window.location.href + '&text=' + this.get('model.title') + '&via=OSFramework');
     }),
@@ -35,9 +34,6 @@ export default Ember.Controller.extend({
     }),
 
     actions: {
-        toggleShare() {
-            this.toggleProperty('expandShare');
-        },
         expandMFR() {
             this.toggleProperty('fullScreenMFR');
         },
@@ -49,7 +45,6 @@ export default Ember.Controller.extend({
         },
         shareLink(href) {
             window.open(href, '', 'menubar=no,toolbar=no,resizable=yes,scrollbars=yes,width=600,height=400');
-            this.toggleProperty('expandShare');
             return false;
         }
     },

--- a/app/controllers/content.js
+++ b/app/controllers/content.js
@@ -6,16 +6,16 @@ export default Ember.Controller.extend({
     expandedAuthors: true,
     expandShare: false,
     twitterHref: Ember.computed('model', function() {
-        return 'https://twitter.com/intent/tweet?url=' + window.location.href + '&text=' + this.get('model.title') + '&via=OSFramework';
+        return encodeURI('https://twitter.com/intent/tweet?url=' + window.location.href + '&text=' + this.get('model.title') + '&via=OSFramework');
     }),
     facebookHref: Ember.computed('model', function() {
-        return 'https://www.facebook.com/sharer/sharer.php?u=' + window.location.href;
+        return encodeURI('https://www.facebook.com/sharer/sharer.php?u=' + window.location.href);
     }),
     linkedinHref: Ember.computed('model', function() {
-        return 'https://www.linkedin.com/cws/share?url=' + window.location.href + '&title=' + this.get('model.title');
+        return encodeURI('https://www.linkedin.com/cws/share?url=' + window.location.href + '&title=' + this.get('model.title'));
     }),
     emailHref: Ember.computed('model', function() {
-        return 'mailto:?subject=' + this.get('model.title') + '&body=' + window.location.href;
+        return encodeURI('mailto:?subject=' + this.get('model.title') + '&body=' + window.location.href);
     }),
     // The currently selected file (defaults to primary)
     activeFile: null,

--- a/app/controllers/content.js
+++ b/app/controllers/content.js
@@ -15,7 +15,7 @@ export default Ember.Controller.extend({
         return encodeURI('https://www.linkedin.com/cws/share?url=' + window.location.href + '&title=' + this.get('model.title'));
     }),
     emailHref: Ember.computed('model', function() {
-        return encodeURI('mailto:?subject=' + this.get('model.title') + '&body=' + window.location.href);
+        return 'mailto:?subject=' + encodeURIComponent(this.get('model.title') + '&body=' + window.location.href);
     }),
     // The currently selected file (defaults to primary)
     activeFile: null,

--- a/app/templates/content.hbs
+++ b/app/templates/content.hbs
@@ -39,20 +39,16 @@
                                 <span class="p-sm pull-right">
                                     <p class="f-w-lg">
                                         <a href='' {{action 'toggleShare'}} class='link-solid'>Share</a>
-                                        {{!-- Disable until share/edit functionality is available
-                                        {{#link-to "preprints.edit" class="link-solid m-r-xs"}}Edit{{/link-to}}
-                                        {{#link-to "preprints.edit" class="link-solid"}}Share{{/link-to}}
-                                        --}}
                                     </p>
                                 </span>
                             </div>
                         {{#if expandShare}}
                             <div class="row osf-box-lt">
                                 <span class="p-sm pull-right" >
-                                    <a style='margin: 5px' href=''>{{fa-icon 'twitter' size=2 }}</a>
-                                    <a style='margin: 5px' href=''>{{fa-icon 'facebook' size=2 }}</a>
-                                    <a style='margin: 5px' href=''>{{fa-icon 'linkedin' size=2 }}</a>
-                                    <a style='margin: 5px' href=''>{{fa-icon 'envelope' size=2 }}</a>
+                                    <a style='margin: 5px' href={{twitterHref}}>{{fa-icon 'twitter' size=2 }}</a>
+                                    <a style='margin: 5px' href={{facebookHref}}>{{fa-icon 'facebook' size=2 }}</a>
+                                    <a style='margin: 5px' href={{linkedinHref}}>{{fa-icon 'linkedin' size=2 }}</a>
+                                    <a style='margin: 5px' href={{mailHref}}>{{fa-icon 'envelope' size=2 }}</a>
                                     <a style='margin: 5px; margin-right: -50px' href='' {{action 'toggleShare'}} class='link-solid'>Dismiss</a>
                                 </span>
                             </div>

--- a/app/templates/content.hbs
+++ b/app/templates/content.hbs
@@ -31,30 +31,18 @@
             {{#unless fullScreenMFR}}
                 <div class="col-md-5"> {{!RIGHT SIDE COL}}
                     {{#liquid-spacer growDuration=250 growWidth=false}}
-
                         <div class="p-sm osf-box-lt">{{!SHARE ROW}}
-                            <div class="osf-box-lt" id="download_project">
+                            <div class="" id="download_project">
                                 <a class="btn btn-primary" href={{activeFile.links.download}}>Download</a>
                                 <span class="p-sm">Downloads: {{activeFile.extra.downloads}}</span>
-                                <span class="p-sm pull-right">
-                                    <p class="f-w-lg">
-                                        <a href='' {{action 'toggleShare'}} class='link-solid'>Share</a>
-                                    </p>
+                                <span class="p-xs pull-right">
+                                    <a class="m-h-xs text-smaller" href={{twitterHref}} onclick={{action 'shareLink' twitterHref}}>{{fa-icon 'twitter-square' size=2 }}</a>
+                                    <a class="m-h-xs text-smaller" href={{facebookHref}} onclick={{action 'shareLink' facebookHref}}>{{fa-icon 'facebook-square' size=2 }}</a>
+                                    <a class="m-h-xs text-smaller" href={{linkedinHref}} onclick={{action 'shareLink' linkedinHref}}>{{fa-icon 'linkedin-square' size=2 }}</a>
+                                    <a class="m-h-xs text-smaller" href={{emailHref}} onclick={{action 'shareLink' emailHref}}>{{fa-icon 'envelope' size=2 }}</a>
                                 </span>
                             </div>
-                            {{#if expandShare}}
-                                <div class="row osf-box-lt">
-                                    <span class="p-sm pull-right" >
-                                        <a style='margin: 5px' href={{twitterHref}} onclick={{action 'shareLink' twitterHref}}>{{fa-icon 'twitter' size=2 }}</a>
-                                        <a style='margin: 5px' href={{facebookHref}} onclick={{action 'shareLink' facebookHref}}>{{fa-icon 'facebook' size=2 }}</a>
-                                        <a style='margin: 5px' href={{linkedinHref}} onclick={{action 'shareLink' linkedinHref}}>{{fa-icon 'linkedin' size=2 }}</a>
-                                        <a style='margin: 5px' href={{emailHref}} onclick={{action 'shareLink' emailHref}}>{{fa-icon 'envelope' size=2 }}</a>
-                                        <a style='margin: 5px; margin-right: -50px' href='' {{action 'toggleShare'}} class='link-solid'>Dismiss</a>
-                                    </span>
-                                </div>
-                            {{/if}}
                         </div>
-
 
                     {{/liquid-spacer}}
                     <div class="p-t-xs">

--- a/app/templates/content.hbs
+++ b/app/templates/content.hbs
@@ -42,17 +42,17 @@
                                     </p>
                                 </span>
                             </div>
-                        {{#if expandShare}}
-                            <div class="row osf-box-lt">
-                                <span class="p-sm pull-right" >
-                                    <a style='margin: 5px' href={{twitterHref}} onclick={{action 'shareLink' twitterHref}}>{{fa-icon 'twitter' size=2 }}</a>
-                                    <a style='margin: 5px' href={{facebookHref}} onclick={{action 'shareLink' facebookHref}}>{{fa-icon 'facebook' size=2 }}</a>
-                                    <a style='margin: 5px' href={{linkedinHref}} onclick={{action 'shareLink' linkedinHref}}>{{fa-icon 'linkedin' size=2 }}</a>
-                                    <a style='margin: 5px' href={{emailHref}} onclick={{action 'shareLink' emailHref}}>{{fa-icon 'envelope' size=2 }}</a>
-                                    <a style='margin: 5px; margin-right: -50px' href='' {{action 'toggleShare'}} class='link-solid'>Dismiss</a>
-                                </span>
-                            </div>
-                        {{/if}}
+                            {{#if expandShare}}
+                                <div class="row osf-box-lt">
+                                    <span class="p-sm pull-right" >
+                                        <a style='margin: 5px' href={{twitterHref}} onclick={{action 'shareLink' twitterHref}}>{{fa-icon 'twitter' size=2 }}</a>
+                                        <a style='margin: 5px' href={{facebookHref}} onclick={{action 'shareLink' facebookHref}}>{{fa-icon 'facebook' size=2 }}</a>
+                                        <a style='margin: 5px' href={{linkedinHref}} onclick={{action 'shareLink' linkedinHref}}>{{fa-icon 'linkedin' size=2 }}</a>
+                                        <a style='margin: 5px' href={{emailHref}} onclick={{action 'shareLink' emailHref}}>{{fa-icon 'envelope' size=2 }}</a>
+                                        <a style='margin: 5px; margin-right: -50px' href='' {{action 'toggleShare'}} class='link-solid'>Dismiss</a>
+                                    </span>
+                                </div>
+                            {{/if}}
                         </div>
 
 

--- a/app/templates/content.hbs
+++ b/app/templates/content.hbs
@@ -48,7 +48,7 @@
                                     <a style='margin: 5px' href={{twitterHref}} onclick={{action 'shareLink' twitterHref}}>{{fa-icon 'twitter' size=2 }}</a>
                                     <a style='margin: 5px' href={{facebookHref}} onclick={{action 'shareLink' facebookHref}}>{{fa-icon 'facebook' size=2 }}</a>
                                     <a style='margin: 5px' href={{linkedinHref}} onclick={{action 'shareLink' linkedinHref}}>{{fa-icon 'linkedin' size=2 }}</a>
-                                    <a style='margin: 5px' href={{mailHref}} onclick={{action 'shareLink' mailHref}}>{{fa-icon 'envelope' size=2 }}</a>
+                                    <a style='margin: 5px' href={{emailHref}} onclick={{action 'shareLink' emailHref}}>{{fa-icon 'envelope' size=2 }}</a>
                                     <a style='margin: 5px; margin-right: -50px' href='' {{action 'toggleShare'}} class='link-solid'>Dismiss</a>
                                 </span>
                             </div>

--- a/app/templates/content.hbs
+++ b/app/templates/content.hbs
@@ -30,18 +30,37 @@
             </div> {{!END LEFT COL DIV}}
             {{#unless fullScreenMFR}}
                 <div class="col-md-5"> {{!RIGHT SIDE COL}}
-                    <div class="p-sm osf-box-lt" id="download_project">{{!SHARE ROW}}
-                        <a class="btn btn-primary" href={{activeFile.links.download}}>Download</a>
-                        <span class="p-sm pull-right">Downloads: {{activeFile.extra.downloads}}</span>
-                        <span class="p-sm pull-right">
-                            <p class="f-w-lg">
-                                {{!-- Disable until share/edit functionality is available
-                                {{#link-to "preprints.edit" class="link-solid m-r-xs"}}Edit{{/link-to}}
-                                {{#link-to "preprints.edit" class="link-solid"}}Share{{/link-to}}
-                                --}}
-                            </p>
-                        </span>
-                    </div>{{!END SHARE ROW}}
+                    {{#liquid-spacer growDuration=250 growWidth=false}}
+
+                        <div class="p-sm osf-box-lt">{{!SHARE ROW}}
+                            <div class="osf-box-lt" id="download_project">
+                                <a class="btn btn-primary" href={{activeFile.links.download}}>Download</a>
+                                <span class="p-sm">Downloads: {{activeFile.extra.downloads}}</span>
+                                <span class="p-sm pull-right">
+                                    <p class="f-w-lg">
+                                        <a href='' {{action 'toggleShare'}} class='link-solid'>Share</a>
+                                        {{!-- Disable until share/edit functionality is available
+                                        {{#link-to "preprints.edit" class="link-solid m-r-xs"}}Edit{{/link-to}}
+                                        {{#link-to "preprints.edit" class="link-solid"}}Share{{/link-to}}
+                                        --}}
+                                    </p>
+                                </span>
+                            </div>
+                        {{#if expandShare}}
+                            <div class="row osf-box-lt">
+                                <span class="p-sm pull-right" >
+                                    <a style='margin: 5px' href=''>{{fa-icon 'twitter' size=2 }}</a>
+                                    <a style='margin: 5px' href=''>{{fa-icon 'facebook' size=2 }}</a>
+                                    <a style='margin: 5px' href=''>{{fa-icon 'linkedin' size=2 }}</a>
+                                    <a style='margin: 5px' href=''>{{fa-icon 'envelope' size=2 }}</a>
+                                    <a style='margin: 5px; margin-right: -50px' href='' {{action 'toggleShare'}} class='link-solid'>Dismiss</a>
+                                </span>
+                            </div>
+                        {{/if}}
+                        </div>
+
+
+                    {{/liquid-spacer}}
                     <div class="p-t-xs">
                         <h4 class="p-v-md f-w-md">Abstract</h4>
                         <p class="abstract">{{model.abstract}}</p>

--- a/app/templates/content.hbs
+++ b/app/templates/content.hbs
@@ -45,10 +45,10 @@
                         {{#if expandShare}}
                             <div class="row osf-box-lt">
                                 <span class="p-sm pull-right" >
-                                    <a style='margin: 5px' href={{twitterHref}}>{{fa-icon 'twitter' size=2 }}</a>
-                                    <a style='margin: 5px' href={{facebookHref}}>{{fa-icon 'facebook' size=2 }}</a>
-                                    <a style='margin: 5px' href={{linkedinHref}}>{{fa-icon 'linkedin' size=2 }}</a>
-                                    <a style='margin: 5px' href={{mailHref}}>{{fa-icon 'envelope' size=2 }}</a>
+                                    <a style='margin: 5px' href={{twitterHref}} onclick={{action 'shareLink' twitterHref}}>{{fa-icon 'twitter' size=2 }}</a>
+                                    <a style='margin: 5px' href={{facebookHref}} onclick={{action 'shareLink' facebookHref}}>{{fa-icon 'facebook' size=2 }}</a>
+                                    <a style='margin: 5px' href={{linkedinHref}} onclick={{action 'shareLink' linkedinHref}}>{{fa-icon 'linkedin' size=2 }}</a>
+                                    <a style='margin: 5px' href={{mailHref}} onclick={{action 'shareLink' mailHref}}>{{fa-icon 'envelope' size=2 }}</a>
                                     <a style='margin: 5px; margin-right: -50px' href='' {{action 'toggleShare'}} class='link-solid'>Dismiss</a>
                                 </span>
                             </div>


### PR DESCRIPTION
Adds social media share buttons to the view preprint page. Matches the behavior and buttons of public projects social media sharing. Uses liquid-fire to animate the toggling of the share row.