### PR TITLE
Change discover page query param from pushstate to replaceState [PREP-169]

### DIFF
--- a/app/routes/discover.js
+++ b/app/routes/discover.js
@@ -4,7 +4,7 @@ import ResetScrollMixin from '../mixins/reset-scroll';
 export default Ember.Route.extend(ResetScrollMixin, {
     queryParams: {
         queryString: {
-          replace: true
+            replace: true
         }
-      }
+    }
 });

--- a/app/routes/discover.js
+++ b/app/routes/discover.js
@@ -2,6 +2,9 @@ import Ember from 'ember';
 import ResetScrollMixin from '../mixins/reset-scroll';
 
 export default Ember.Route.extend(ResetScrollMixin, {
-
+    queryParams: {
+        queryString: {
+          replace: true
+        }
+      }
 });
-


### PR DESCRIPTION
## Ticket
https://openscience.atlassian.net/browse/PREP-169

## Purpose
Search page should not save each keyup as query parameter changes into history

## Changes
Use a standard procedure in Ember (https://guides.emberjs.com/v2.3.0/routing/query-params/#toc_update-url-with-code-replacestate-code-instead) to change the queryparam from pushState to replaceState. 

## Testing Considerations
- Open new browser tab or window
- Start searching for preprints in discover page by adding several keywords and wait for page to load.
- Click the back button of browser or right click to see all previous pages
- Check that individual word entries are not in the history, back button should go to empty discover page or previous pages. 
