### PR TITLE
Fix tag widget layout in narrow screens [PREP-176]

### DIFF
--- a/app/templates/submit.hbs
+++ b/app/templates/submit.hbs
@@ -83,7 +83,7 @@
                                             </label>
                                             {{validated-input model=this valuePath='basicsDOI' placeholder="DOI" value=basicsDOI}}
                                         </div>
-                                        <div>
+                                        <div class="clearfix">
                                             <label>
                                                 Keywords:
                                             </label>


### PR DESCRIPTION
## Ticket
https://openscience.atlassian.net/browse/PREP-176

## Purpose
Fixes issue where in narrow screens the layout of the tags caused it to be covered up by other divs rendering tags unusable. 

## Changes
Added clearfix to containing div to account for left alignment of the tags widget.