### PR TITLE
Fix education tooltip by adding size to tooltip [PREP-172]

### DIFF
--- a/app/templates/components/taxonomy-top-list.hbs
+++ b/app/templates/components/taxonomy-top-list.hbs
@@ -1,7 +1,7 @@
 {{#each sortedList as |pair|}}
     <div class="subject row m-b-sm">
         {{#each pair as |subject|}}
-            <div class="col-sm-6 subject-item {{if (get subjectTooltips subject.text) 'hint--bottom hint--large'}}" aria-label={{get subjectTooltips subject.text}}>
+            <div class="col-xs-12 col-sm-6 subject-item {{if (get subjectTooltips subject.text) 'hint--bottom hint--large'}}" aria-label={{get subjectTooltips subject.text}}>
                 {{#link-to 'discover' (query-params subjectFilter=subject.text) class='btn btn-primary p-sm'}}
                     {{subject.text}}
                 {{/link-to}}

--- a/app/templates/components/taxonomy-top-list.hbs
+++ b/app/templates/components/taxonomy-top-list.hbs
@@ -1,7 +1,7 @@
 {{#each sortedList as |pair|}}
     <div class="subject row m-b-sm">
         {{#each pair as |subject|}}
-            <div class="col-sm-6 subject-item {{if (get subjectTooltips subject.text) 'hint--bottom'}}" aria-label={{get subjectTooltips subject.text}}>
+            <div class="col-sm-6 subject-item {{if (get subjectTooltips subject.text) 'hint--bottom hint--large'}}" aria-label={{get subjectTooltips subject.text}}>
                 {{#link-to 'discover' (query-params subjectFilter=subject.text) class='btn btn-primary p-sm'}}
                     {{subject.text}}
                 {{/link-to}}


### PR DESCRIPTION
## Ticket
https://openscience.atlassian.net/browse/PREP-172

## Purpose
Improve tooltips by adding size; which takes care of tooltips getting out of the viewport problem for education and also other items. 

## Changes
- add hint--large class to designate size to taxonomy
- added bonus: add xs sizing so that taxonomy objects appear with correct width at smallest window widths. 