### PR TITLE
[Hotfix] Prevents Multiclicking of Share Button

### DIFF
--- a/app/components/confirm-share-preprint.js
+++ b/app/components/confirm-share-preprint.js
@@ -2,11 +2,13 @@ import Ember from 'ember';
 
 export default Ember.Component.extend({
     isOpen: false,
+    shareButtonDisabled: false,
     actions: {
         close() {
             this.set('isOpen', false);
         },
         savePreprint() {
+            this.set('shareButtonDisabled', true);
             this.attrs.savePreprint();
         }
     }

--- a/app/templates/components/confirm-share-preprint.hbs
+++ b/app/templates/components/confirm-share-preprint.hbs
@@ -9,7 +9,7 @@
     {{#bs-modal-footer}}
         <div align="right">
             <button {{action 'close'}} class="btn btn-default"> Cancel </button>
-            <a class="btn btn-success" {{action 'savePreprint'}}>Share </a>
+            <button class="btn btn-success" disabled={{shareButtonDisabled}} {{action 'savePreprint'}}>Share</button>
         </div>
     {{/bs-modal-footer}}
 {{/bs-modal}}


### PR DESCRIPTION
# Purpose

Share button can be clicked multiple times which could result in a 405 "Could not save preprint; please try again later."

# Changes

Disables 'Share' button on Add Preprint page after it's been clicked.