### PR TITLE
Make sure filters actually have a value

### DIFF
--- a/app/controllers/discover.js
+++ b/app/controllers/discover.js
@@ -92,7 +92,7 @@ export default Ember.Controller.extend({
     subjectChanged: Ember.observer('subjectFilter', function() {
         Ember.run.once(() => {
             let filter = this.get('subjectFilter');
-            if (!filter) return;
+            if (!filter || filter === 'true') return;
             this.set('activeFilters.subjects', filter.split('AND'));
             this.notifyPropertyChange('activeFilters');
             this.loadPage();
@@ -101,7 +101,7 @@ export default Ember.Controller.extend({
     providerChanged: Ember.observer('providerFilter', function() {
         Ember.run.once(() => {
             let filter = this.get('providerFilter');
-            if (!filter) return;
+            if (!filter || filter === 'true') return;
             this.set('activeFilters.providers', filter.split('AND'));
             this.notifyPropertyChange('activeFilters');
             this.set('providersPassed', true);


### PR DESCRIPTION
## Purpose:
When pasting a link something like `subject=` gets converted to `subject`, which Ember reads as a value of ` true ` to the Subject query param. When trying to convert query params to filters, it is read as string ` true `. This prevents that behavior (but it does not validate the value of the query param if something is actually passed).

## Changes:
If a queryParam's value is ` true`, do not use it as a filter.