### PR TITLE
Feature/expose primary file version [PREP-144]

### DIFF
--- a/app/locales/en/translations.js
+++ b/app/locales/en/translations.js
@@ -28,7 +28,9 @@ export default {
         },
         share: {
             download: `Download`,
-            downloads: `Downloads`
+            downloads: `Downloads`,
+            download_file: `Download file`,
+            download_preprint: `Download preprint`
         },
         version: 'Version',
         article_doi: `Article DOI`,

--- a/app/locales/en/translations.js
+++ b/app/locales/en/translations.js
@@ -30,6 +30,7 @@ export default {
             download: `Download`,
             downloads: `Downloads`
         },
+        version: 'Version',
         article_doi: `Article DOI`,
         disciplines: `Disciplines`,
         project_button: {

--- a/app/templates/components/supplementary-file-browser.hbs
+++ b/app/templates/components/supplementary-file-browser.hbs
@@ -2,8 +2,19 @@
     width="99%" height="700"}}
 {{/file-renderer}}
 
+<div class="row">
+    <div class="col-xs-8">
+        <p class="f-w-lg p-b-md">{{selectedFile.name}}</p>
+    </div>
+    <div class="col-xs-4 pull-right text-nowrap">
+        {{#if (and hasAdditionalFiles (not-eq selectedFile.id preprint.primaryFile.id))}}
+            <a class="btn btn-default btn-sm" href={{selectedFile.links.download}}>{{t "content.share.download_file"}}</a>
+        {{/if}}
+        <span class="p-sm pull-right"> {{t "content.version"}}: {{selectedFile.currentVersion}}</span>
+    </div>
+</div>
+
 {{#if hasAdditionalFiles}}
-    <p class="f-w-lg p-b-md">{{selectedFile.name}}</p>
     <section class="osf-box p-md m-b-lg">
         {{#liquid-bind (slice-array files startIndex endIndex) use=scrollAnim as |list|}}
             {{#each list as |supplement index|}}

--- a/app/templates/components/supplementary-file-browser.hbs
+++ b/app/templates/components/supplementary-file-browser.hbs
@@ -6,11 +6,13 @@
     <div class="col-xs-8">
         <p class="f-w-lg p-b-md">{{selectedFile.name}}</p>
     </div>
-    <div class="col-xs-4 pull-right text-nowrap">
-        {{#if (and hasAdditionalFiles (not-eq selectedFile.id preprint.primaryFile.id))}}
-            <a class="btn btn-default btn-sm" href={{selectedFile.links.download}}>{{t "content.share.download_file"}}</a>
-        {{/if}}
-        <span class="p-sm pull-right"> {{t "content.version"}}: {{selectedFile.currentVersion}}</span>
+    <div class="col-xs-4 text-nowrap">
+        <div class="pull-right">
+            {{#if (and hasAdditionalFiles (not-eq selectedFile.id preprint.primaryFile.id))}}
+                <a class="btn btn-default btn-sm" href={{selectedFile.links.download}}>{{t "content.share.download_file"}}</a>
+            {{/if}}
+            <span class="p-sm"> {{t "content.version"}}: {{selectedFile.currentVersion}}</span>
+        </div>
     </div>
 </div>
 

--- a/app/templates/content.hbs
+++ b/app/templates/content.hbs
@@ -35,9 +35,8 @@
                     {{#liquid-spacer growDuration=250 growWidth=false}}
                         <div class="p-sm osf-box-lt clearfix">{{!SHARE ROW}}
                             <div class="" id="download_project clearfix">
-                                <a class="btn btn-primary" href={{activeFile.links.download}}>{{t "content.share.download"}}</a>
+                                <a class="btn btn-primary" href={{model.primaryFile.links.download}}>{{t "content.share.download_preprint"}}</a>
                                 <span class="p-sm">{{t "content.share.downloads"}}: {{activeFile.extra.downloads}}</span>
-                                <span class="p-sm"> {{t "content.version"}}: {{activeFile.currentVersion}}</span>
                                 <span class="p-xs pull-right">
                                     <a class="m-r-xs text-smaller" href={{twitterHref}} onclick={{action 'shareLink' twitterHref}}>{{fa-icon 'twitter-square' size=2 }}</a>
                                     <a class="m-r-xs text-smaller" href={{facebookHref}} onclick={{action 'shareLink' facebookHref}}>{{fa-icon 'facebook-square' size=2 }}</a>

--- a/app/templates/content.hbs
+++ b/app/templates/content.hbs
@@ -37,6 +37,7 @@
                             <div class="" id="download_project clearfix">
                                 <a class="btn btn-primary" href={{activeFile.links.download}}>{{t "content.share.download"}}</a>
                                 <span class="p-sm">{{t "content.share.downloads"}}: {{activeFile.extra.downloads}}</span>
+                                <span class="p-sm"> {{t "content.version"}}: {{activeFile.currentVersion}}</span>
                                 <span class="p-xs pull-right">
                                     <a class="m-r-xs text-smaller" href={{twitterHref}} onclick={{action 'shareLink' twitterHref}}>{{fa-icon 'twitter-square' size=2 }}</a>
                                     <a class="m-r-xs text-smaller" href={{facebookHref}} onclick={{action 'shareLink' facebookHref}}>{{fa-icon 'facebook-square' size=2 }}</a>

--- a/tests/integration/components/supplementary-file-browser-test.js
+++ b/tests/integration/components/supplementary-file-browser-test.js
@@ -30,7 +30,7 @@ test('it renders', function(assert) {
 
     this.render(hbs`{{supplementary-file-browser preprint=preprint}}`);
 
-    assert.equal(this.$().text().trim(), '');
+    assert.equal(this.$().text().trim(), 'Version:');
 
     //  this.on('changeFile', function() {});
 });


### PR DESCRIPTION
## Ticket

Needed for https://openscience.atlassian.net/browse/PREP-144

## Purpose

The version of the primary file for the preprint needs to be exposed in the view preprint page.

## Changes 

Adds version of the selected file and a download link for the selected file to the view preprint page.  Download preprint button just downloads primary file.

![screen shot 2016-09-27 at 11 42 29 am](https://cloud.githubusercontent.com/assets/9755598/18880992/c4b70f74-84a7-11e6-9bd6-3ccbabd02384.png)
