### PR TITLE
Feature/Pin to Corresponding Ember-OSF Commit

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "ember-get-config": "0.0.4",
     "ember-i18n": "4.3.1",
     "ember-load-initializers": "^0.5.1",
-    "ember-osf": "git+https://github.com/CenterForOpenScience/ember-osf.git#3763baf49ba4ae294f6459e21bed40d748ea17e6",
+    "ember-osf": "git+https://github.com/CenterForOpenScience/ember-osf.git#355e9f77a4c77d53171a2d49de8843adf4cac1f6",
     "ember-page-title": "3.0.6",
     "ember-power-select": "1.0.0-beta.7",
     "ember-read-more": "0.0.13",


### PR DESCRIPTION
# Purpose

Links work done in https://github.com/CenterForOpenScience/ember-preprints/pull/141 to latest ember-osf version.