### PR TITLE
Feature/Changes for Existing OSF Project Workflow [PREP-142] [PREP-200]

### DIFF
--- a/app/components/confirm-share-preprint.js
+++ b/app/components/confirm-share-preprint.js
@@ -9,7 +9,10 @@ export default Ember.Component.extend({
         },
         savePreprint() {
             this.set('shareButtonDisabled', true);
-            this.attrs.savePreprint();
+            this.attrs.savePreprint().catch(() => {
+                    this.toast.error('Could not save preprint; please try again later');
+                    this.set('shareButtonDisabled', false);
+                });
         }
     }
 });

--- a/app/components/file-uploader.js
+++ b/app/components/file-uploader.js
@@ -176,7 +176,7 @@ export default Ember.Component.extend({
         },
         formatDropzoneAfterPreUpload() {
             this.$('.dz-default.dz-message').before(this.$('.dz-preview.dz-file-preview'));
-            this.$('.dz-message span').contents().replaceWith('Click or drag another preprint file to swap');
+            this.$('.dz-message span').contents().replaceWith('Click or drag another preprint file to replace');
             this.$('.dropzone').addClass('successHighlightGreenGray');
 
             setTimeout(() => {

--- a/app/controllers/submit.js
+++ b/app/controllers/submit.js
@@ -397,7 +397,7 @@ export default Ember.Controller.extend(BasicsValidations, NodeActionsMixin, Tagg
             if (model.get('doi') === '') {
                 model.set('doi', undefined);
             }
-            model.save()
+            return model.save()
                 // Ember data is not worth the time investment currently
                 .then(() =>  this.store.adapterFor('preprint').ajax(model.get('links.relationships.providers.links.self.href'), 'PATCH', {
                     data: {
@@ -408,8 +408,7 @@ export default Ember.Controller.extend(BasicsValidations, NodeActionsMixin, Tagg
                     }
                 }))
                 .then(() => model.get('providers'))
-                .then(() => this.transitionToRoute('content', model))
-                .catch(() => this.send('error', 'Could not save preprint; please try again later'));
+                .then(() => this.transitionToRoute('content', model));
         },
     }
 });

--- a/app/controllers/submit.js
+++ b/app/controllers/submit.js
@@ -313,11 +313,15 @@ export default Ember.Controller.extend(BasicsValidations, NodeActionsMixin, Tagg
         saveBasics() {
             // Save the model associated with basics field, then advance to next panel
             // If save fails, do not transition
+            this.send('saveAbstract');
+            this.send('next', this.get('_names.2'));
+        },
+
+        saveAbstract() {
             let node = this.get('node');
             node.set('description', this.get('basicsAbstract'));
             node.save()
-                .then(() => this.send('next', this.get('_names.2')))
-                .catch(()=> this.send('error', 'Could not save information; please try again'));
+                .catch(() => this.send('error', 'Could not save information; please try again'));
         },
 
         saveSubjects(subjects) {

--- a/app/controllers/submit.js
+++ b/app/controllers/submit.js
@@ -115,7 +115,7 @@ export default Ember.Controller.extend(BasicsValidations, NodeActionsMixin, Tagg
 
     hasFile: Ember.computed('file', 'selectedFile', function() {
         // True if file has either been preuploaded, or already uploaded file has been selected.
-        return this.get('file') || this.get('selectedFile');
+        return this.get('file') !== null || this.get('selectedFile') !== null;
     }),
 
     ///////////////////////////////////////

--- a/app/locales/en/translations.js
+++ b/app/locales/en/translations.js
@@ -219,7 +219,8 @@ export default {
             no_valid_existing_nodes: `You have no valid nodes that can be converted into a preprint.  Go back to upload a new preprint.`,
             upload_preprint: `Upload preprint`,
             select_existing_file: `Select existing file as preprint`,
-            edit_preprint_title: `Edit preprint title (will also become the name of the project)`,
+            edit_preprint_title_project: `Edit preprint title (will also become the name of the project)`,
+            edit_preprint_title_component: `Edit preprint title (will also become the name of the component)`,
             initiate_preprint_process: `You have selected and organized your preprint file. Clicking "Save and continue" will immediately make changes to your OSF project.`,
             admin_only: `You must be the admin of this component to share it.  Please ask the admin of this project to make you an admin so you may share this component.`
         },

--- a/app/locales/en/translations.js
+++ b/app/locales/en/translations.js
@@ -19,10 +19,9 @@ export default {
         restart: `Restart`,
         no_results_found: `No results found.`,
         authors: `Authors`,
-        convert_project: `The current project will contain the preprint.`,
-        convert_component: `The current component will contain the preprint`,
-        copy_inside_project: `A new component inside the current project will contain the preprint.`,
-        copy_inside_component: `A new component inside the current component will contain the preprint.`,
+        convert_project: `The preprint will be organized in the current project`,
+        convert_component: `The preprint will be organized in the current component`,
+        copy_inside_project: `The preprint will be organized in a new component`,
     },
     application: {
         // Nothing to translate
@@ -150,12 +149,12 @@ export default {
             body: `Once this preprint is made public, you should assume that it will always be public. Even if you delete it, search engines or others may access the files before you do so.`
         },
         'convert-or-copy': {
-            organize_language_project: `You have a choice for how to organize your preprint in this project. If you select, "Make a new component", then the preprint file will
-            be placed in a new component inside the current project.  If you select "Use the current project", then the preprint file will be placed inside the
-            current project. If you are unsure, then select "Make a new component".`,
-            organize_language_component: `You have a choice for how to organize your preprint in this component. If you select, "Make a new component", then the preprint file will
-            be placed in a new component inside the current component.  If you select "Use the current component", then the preprint file will be placed inside the
-            current component. If you are unsure, then select "Make a new component".`,
+            organize_language_project: `You can organize your preprint by storing the file in this project or in its own new component.  If you select ‘Make a new component’, 
+            the preprint file will be stored in a new component inside this project.  If you select ‘Use the current project’, the preprint file will be stored in this project. 
+            If you are unsure, select ‘Make a new component’.`,
+            organize_language_component: `You can organize your preprint by storing the file in this component or in its own new component.  If you select ‘Make a new component’, 
+            the preprint file will be stored in a new component inside this component.  If you select ‘Use the current component’, the preprint file will be stored in this component. 
+            If you are unsure, select ‘Make a new component’.`,
             copy: `Make a new component`,
             convert_project: `Use the current project`,
             convert_component: `Use the current component`,
@@ -221,7 +220,7 @@ export default {
             upload_preprint: `Upload preprint`,
             select_existing_file: `Select existing file as preprint`,
             edit_preprint_title: `Edit preprint title`,
-            initiate_preprint_process: `You are about to initiate the preprint process.  You will not be able to change your project or file after this point.`,
+            initiate_preprint_process: `You have selected and organized your preprint file and any changes will be permanent.`,
             admin_only: `You must be the admin of this component to share it.  Please ask the admin of this project to make you an admin so you may share this component.`
         },
         'preprint-form-section': {

--- a/app/locales/en/translations.js
+++ b/app/locales/en/translations.js
@@ -219,8 +219,8 @@ export default {
             no_valid_existing_nodes: `You have no valid nodes that can be converted into a preprint.  Go back to upload a new preprint.`,
             upload_preprint: `Upload preprint`,
             select_existing_file: `Select existing file as preprint`,
-            edit_preprint_title: `Edit preprint title`,
-            initiate_preprint_process: `You have selected and organized your preprint file and any changes will be permanent.`,
+            edit_preprint_title: `Edit preprint title (will also become the name of the project)`,
+            initiate_preprint_process: `You have selected and organized your preprint file. Clicking "Save and continue" will immediately make changes to your OSF project.`,
             admin_only: `You must be the admin of this component to share it.  Please ask the admin of this project to make you an admin so you may share this component.`
         },
         'preprint-form-section': {

--- a/app/routes/submit.js
+++ b/app/routes/submit.js
@@ -41,8 +41,9 @@ export default Ember.Route.extend(AnalyticsMixin, ResetScrollMixin, CasAuthentic
         willTransition: function(transition) {
             // Displays confirmation message if user attempts to navigate away from Add Preprint process with unsaved changes
             var controller = this.get('controller');
+            var hasFile = controller.get('file') !== null || controller.get('selectedFile') !== null;
 
-            if (controller.get('hasFile') && !controller.get('savingPreprint') && !confirm('Are you sure you want to abandon this preprint?')) {
+            if (hasFile && !controller.get('savingPreprint') && !confirm('Are you sure you want to abandon this preprint?')) {
                 transition.abort();
             }
         }

--- a/app/templates/components/file-uploader.hbs
+++ b/app/templates/components/file-uploader.hbs
@@ -59,7 +59,7 @@
                 {{#preprint-form-body}}
                     {{#if (eq convertOrCopy 'convert')}}
                         {{#if convertProjectConfirmed}}
-                            <label class="text-muted title-label"> {{t "components.preprint-form-project-select.edit_preprint_title"}} </label>
+                            <label class="text-muted title-label"> {{if isTopLevelNode (t "components.preprint-form-project-select.edit_preprint_title_project") (t "components.preprint-form-project-select.edit_preprint_title_component")}} </label>
                         {{/if}}
                     {{/if}}
                     {{preprint-title-editor nodeTitle=nodeTitle titleValid=titleValid}}

--- a/app/templates/components/preprint-form-header.hbs
+++ b/app/templates/components/preprint-form-header.hbs
@@ -93,11 +93,7 @@
 
             {{#if (eq convertOrCopy 'copy')}}
                 <p>
-                {{#if isTopLevelNode}}
-                        {{t "global.copy_inside_project"}}
-                    {{else}}
-                        {{t "global.copy_inside_component"}}
-                    {{/if}}
+                    {{t "global.copy_inside_project"}}
                 </p>
             {{/if}}
         {{/if}}

--- a/app/templates/components/preprint-form-project-select.hbs
+++ b/app/templates/components/preprint-form-project-select.hbs
@@ -79,7 +79,7 @@
                                     {{#preprint-form-body}}
                                         {{#if (eq convertOrCopy 'convert')}}
                                             {{#if convertProjectConfirmed}}
-                                                <label class="text-muted title-label"> {{t "components.preprint-form-project-select.edit_preprint_title"}} </label>
+                                                <label class="text-muted title-label">  {{if isTopLevelNode (t "components.preprint-form-project-select.edit_preprint_title_project") (t "components.preprint-form-project-select.edit_preprint_title_component")}} </label>
                                             {{/if}}
                                         {{/if}}
                                         {{preprint-title-editor nodeTitle=nodeTitle titleValid=titleValid}}

--- a/app/templates/submit.hbs
+++ b/app/templates/submit.hbs
@@ -132,10 +132,12 @@
                                         </div>
                                     </div>
                                     <div class="col-md-6">
-                                        <label>
-                                            <span class="required">{{t "global.abstract"}}:</span>
-                                        </label>
-                                        {{validated-input model=this valuePath='basicsAbstract' placeholder=(t "submit.body.basics.abstract.placeholder") value=basicsAbstract large=true}}
+                                        <form onchange={{action 'saveAbstract'}}>
+                                            <label>
+                                                <span class="required">{{t "global.abstract"}}:</span>
+                                            </label>
+                                            {{validated-input model=this valuePath='basicsAbstract' placeholder=(t "submit.body.basics.abstract.placeholder") value=basicsAbstract large=true}}
+                                        </form>
                                     </div>
                                 </div>
                                 <div class="row">


### PR DESCRIPTION
# Tickets
https://openscience.atlassian.net/browse/PREP-142, https://openscience.atlassian.net/browse/PREP-200

# Purpose

Language changes and fixes for issues found by QA for Existing OSF Project Workflow

# Changes 
- Language changes
- Fix "Are you sure you want to abandon this preprint" to be raised when navigating away from page when file has been set (either file uploaded or existing file selected).
- Allow abstract to be saved when advancing to next section, not just when 'Save and continue' is clicked.
- If user tries to share preprint, and it fails, reenable share button so they can try again.