### PR TITLE
Make preprints url replacement absolute url [PREP-194]

### DIFF
--- a/app/routes/content.js
+++ b/app/routes/content.js
@@ -15,7 +15,7 @@ export default Ember.Route.extend(AnalyticsMixin, ResetScrollMixin, {
     },
     actions: {
         error(error, transition) {
-            window.history.replaceState({}, 'preprints', 'preprints/' + transition.params.content.preprint_id);
+            window.history.replaceState({}, 'preprints', '/preprints/' + transition.params.content.preprint_id);
             this.intermediateTransitionTo('page-not-found');
         }
     }


### PR DESCRIPTION
Changes the replacestate url to be absolute, not relative; because replacestate will tack on the url if it's relative.