### PR TITLE
Feature/Bulk Add Parent Project Contributors [PREP-142]

### DIFF
--- a/app/components/preprint-form-authors.js
+++ b/app/components/preprint-form-authors.js
@@ -60,26 +60,26 @@ export default CpPanelBodyComponent.extend({
         addContributorsFromParentProject() {
             this.set('parentContributorsAdded', true);
             var parentNode = this.get('parentNode');
-            var contribPromises = [];
+            var contributorsToAdd = Ember.A();
             parentNode.get('contributors').toArray().forEach(contributor => {
                 if (this.get('currentContributorIds').indexOf(contributor.get('userId')) === -1) {
-                    contribPromises.push(this.get('node').addContributor(contributor.get('userId'), contributor.get('permission'), contributor.get('bibliographic'), false).then((contrib) => {
+                    contributorsToAdd.push({
+                        permission: contributor.get('permission'),
+                        bibliographic: contributor.get('bibliographic'),
+                        userId: contributor.get('userId'),
+                    });
+                }
+            });
+            this.attrs.addContributors(contributorsToAdd, false)
+                .then((contributors) => {
+                    contributors.map((contrib) => {
                         this.get('contributors').pushObject(contrib);
-                    }));
-                }
-            });
-            Ember.RSVP.allSettled(contribPromises).then((array) => {
-                this.toggleAuthorModification();
-                var allFulfilled = true;
-                array.forEach((stateObject) => {
-                    if (stateObject.state === 'rejected') {
-                        allFulfilled = false;
-                    }
+                    });
+                    this.toggleAuthorModification();
+                })
+                .catch(() => {
+                    this.get('toast').error('Some contributors may not have been added. Try adding manually.');
                 });
-                if (!allFulfilled) {
-                    this.get('toast').error('Some contributors may not have been added.  Try adding manually.');
-                }
-            });
         },
         // Adds unregistered contributor, then clears form and switches back to search view.
         // Should wait to transition until request has completed.

--- a/app/templates/submit.hbs
+++ b/app/templates/submit.hbs
@@ -166,6 +166,7 @@
                                     canEdit=canEdit
                                     currentUser=user
                                     addContributor=(action 'addContributor')
+                                    addContributors=(action 'addContributors')
                                     findContributors=(action 'findContributors')
                                     searchResults=searchResults
                                     removeContributor=(action 'removeContributor')

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "ember-get-config": "0.0.4",
     "ember-i18n": "4.3.1",
     "ember-load-initializers": "^0.5.1",
-    "ember-osf": "git+https://github.com/CenterForOpenScience/ember-osf.git#355e9f77a4c77d53171a2d49de8843adf4cac1f6",
+    "ember-osf": "git+https://github.com/CenterForOpenScience/ember-osf.git#6314869bc405aea44525b3e71e698a43af861dce",
     "ember-page-title": "3.0.6",
     "ember-power-select": "1.0.0-beta.7",
     "ember-read-more": "0.0.13",


### PR DESCRIPTION
# Purpose

❗ Blocked by https://github.com/CenterForOpenScience/ember-osf/pull/139

There is a feature in Ember preprints that allows you to add contributors from the parent project if a component will contain your preprint. Currently, contributors are added in sequence.  If you have ten contributors on your parent project, any contributors that are not already on component will be added. So nine contributors, nine sequential requests.

This is working locally, but @mfraezz suggested there may be some concurrency issues, so we should attempt to 1) bulk add or 2) wait between requests.  

# Changes

Send adding parent contributors to component as a bulk request.

# Notes

Will need to update package.json with new ember-osf commit once corresponding ember-osf PR is merged.