### PR TITLE
Fix/workflow ui [PREP-203]

### DIFF
--- a/app/styles/app.scss
+++ b/app/styles/app.scss
@@ -998,5 +998,11 @@ label.title-label {
     .toggle-button label.choose-large i {
         font-size: 35px;
     }
+    .panel-body {
+        padding: 0;
+    }
+    .table > tbody > tr > td {
+         padding: 2px;
+    }
 
 }

--- a/app/styles/app.scss
+++ b/app/styles/app.scss
@@ -30,6 +30,9 @@ body {
     font-family: "Open Sans", "Helvetica Neue", sans-serif;
 }
 
+.btn-wrap {
+    white-space: normal;
+}
 ul.comma-list {
     display: inline;
     list-style: none;
@@ -389,6 +392,7 @@ ul.preprints-block-list {
     background-color: #ecf2f3;
     border-bottom: 1px solid #d6dbdc;
 }
+
 
 
 
@@ -983,4 +987,16 @@ label.title-label {
             white-space: pre-line;
         }
     }
+}
+
+// Narrow views for submit
+@media (max-width: 768px) {
+    #preprint-form-upload .btn-big {
+        min-height: 100px;
+        font-size: 14px;
+    }
+    .toggle-button label.choose-large i {
+        font-size: 35px;
+    }
+
 }

--- a/app/styles/app.scss
+++ b/app/styles/app.scss
@@ -342,6 +342,7 @@ ul.preprints-block-list {
         height: 80px;
         font-size: 16px;
         background-color: #eef2f3;
+        white-space: normal;
     }
     .dropzone {
         background-color: #f8f8f8;

--- a/app/styles/app.scss
+++ b/app/styles/app.scss
@@ -377,6 +377,10 @@ ul.preprints-block-list {
     border: 1px solid #ddd;
     margin: 10px;
 }
+.ball-pulse>div {
+    background-color: #b9cdd6;
+}
+
 
 /* Not found page */
 .preprint-404 {

--- a/app/styles/app.scss
+++ b/app/styles/app.scss
@@ -832,7 +832,7 @@ hr {
 
     .file-browser-item {
         height: 30px;
-        padding: 3px;
+        padding: 3px 3px 3px 25px;
     }
 
     .file-browser-item:hover {
@@ -875,6 +875,7 @@ hr {
 
 .exclamation-confirm-convert {
     font-size: 250%;
+    color: $theme-color-light;
 }
 
 
@@ -889,15 +890,10 @@ hr {
         display: inline-block;
         width: 55px;
         background-color: #e4e4e4;
-        color: rgba(0, 0, 0, 0.6);
-        font-size: 12px;
-        font-weight: normal;
+        color: #666666;
         text-align: center;
         text-shadow: none;
         padding: 7px 7px;
-        border: 1px solid rgba(0, 0, 0, 0.2);
-        -webkit-box-shadow: inset 0 1px 3px rgba(0, 0, 0, 0.3), 0 1px rgba(255, 255, 255, 0.1);
-        box-shadow: inset 0 1px 3px rgba(0, 0, 0, 0.3), 0 1px rgba(255, 255, 255, 0.1);
         -webkit-transition: all .3s ease-in-out;
         -moz-transition:    all .3s ease-in-out;
         -ms-transition:     all .3s ease-in-out;
@@ -925,13 +921,16 @@ hr {
         float: none;
         margin-right: -4px;
         padding: 10px 10px;
-        height: 70px;
+        height: 75px;
         font-size: 14px;
-        width: 200px;
-
+        width: 250px;
+        border-right: 1px solid #ccc;
         i {
             font-size: 30px;
         }
+    }
+    label.wide-text-only:last-of-type {
+        border-right: none;
     }
 
 
@@ -941,7 +940,7 @@ hr {
     }
 
     input:checked + label {
-        background-color: #65A0B9;
+        background-color: $theme-color-light;
         color: white;
     }
 

--- a/app/styles/app.scss
+++ b/app/styles/app.scss
@@ -964,9 +964,8 @@ label.title-label {
 
 .preprint-form-section.upload-section-block {
     margin-top: 5px;
-    background: #fff;
     padding:5px 20px 5px 20px;
-    box-shadow: 0 0 3px #ddd;
+    border-top: 1px solid #eee;
 
     header {
         font-size: 15px;

--- a/app/templates/components/convert-or-copy-project.hbs
+++ b/app/templates/components/convert-or-copy-project.hbs
@@ -20,12 +20,12 @@
 {{#liquid-if (and (eq convertOrCopy 'convert') (not convertProjectConfirmed))}}
     <div class="row p-t-md">
         <div class="col-xs-10 col-xs-offset-1">
-            <div class="osf-box p-t-md" role="alert">
+            <div class="osf-box p-md" role="alert">
                 <div class="row">
                     <div class="col-xs-1 text-right">
-                        <h4 class="exclamation-confirm-convert">
+                        <div class="exclamation-confirm-convert">
                             <i class="fa fa-exclamation"></i>
-                        </h4>
+                        </div>
                     </div>
                     <div class="col-xs-10">
                         <h4 class="m-b-md">
@@ -36,7 +36,7 @@
                         </p>
                     </div>
                 </div>
-                <div class="row p-b-md">
+                <div class="row p-t-md">
                     <div class="col-xs-6 text-right">
                         <button {{action "chooseCopyToComponent"}} class="btn btn-default">{{t "components.convert-or-copy.create_a_new_component"}} </button>
                     </div>

--- a/app/templates/components/convert-or-copy-project.hbs
+++ b/app/templates/components/convert-or-copy-project.hbs
@@ -20,7 +20,7 @@
 {{#liquid-if (and (eq convertOrCopy 'convert') (not convertProjectConfirmed))}}
     <div class="row p-t-md">
         <div class="col-xs-10 col-xs-offset-1">
-            <div class="osf-box p-md" role="alert">
+            <div class="osf-box p-md " role="alert">
                 <div class="row">
                     <div class="col-xs-1 text-right">
                         <div class="exclamation-confirm-convert">
@@ -36,15 +36,11 @@
                         </p>
                     </div>
                 </div>
-                <div class="row p-t-md">
-                    <div class="col-xs-6 text-right">
-                        <button {{action "chooseCopyToComponent"}} class="btn btn-default">{{t "components.convert-or-copy.create_a_new_component"}} </button>
-                    </div>
-                    <div class="col-xs-6">
-                        <button {{action "confirmConvert"}} class="btn btn-success">
-                            {{if isTopLevelNode (t "components.convert-or-copy.continue_with_this_project") (t "components.convert-or-copy.continue_with_this_component")}}
-                        </button>
-                    </div>
+                <div class="p-t-md text-right">
+                    <button {{action "chooseCopyToComponent"}} class="btn btn-default">{{t "components.convert-or-copy.create_a_new_component"}} </button>
+                    <button {{action "confirmConvert"}} class="btn btn-success btn-wrap m-t-xs">
+                        {{if isTopLevelNode (t "components.convert-or-copy.continue_with_this_project") (t "components.convert-or-copy.continue_with_this_component")}}
+                    </button>
                 </div>
             </div>
         </div>

--- a/app/templates/components/preprint-form-project-select.hbs
+++ b/app/templates/components/preprint-form-project-select.hbs
@@ -6,9 +6,11 @@
                 {{t "components.preprint-form-project-select.existing_project_selector"}}
             </p>
             {{#if (not userNodesLoaded)}}
-                <div class="text-center">
-                    {{fa-icon 'spinner' pulse=true size=3}}
-
+                <div class="ball-pulse text-center">
+                    <!-- Leave these divs in -->
+                    <div></div>
+                    <div></div>
+                    <div></div>
                 </div>
             {{else}}
                 {{#if userNodes}}

--- a/app/templates/components/preprint-form-project-select.hbs
+++ b/app/templates/components/preprint-form-project-select.hbs
@@ -35,11 +35,11 @@
                         <form class="form">
                             <div class="toggle-button">
                                 <div class="row">
-                                    <div class="col-xs-3 col-xs-offset-3 text-center">
+                                    <div class="col-xs-6 col-sm-3 col-sm-offset-3 text-center">
                                         <input id='existing' class="radio_item" onchange={{action 'changeExistingState' _existingState.NEWFILE}} type="radio" checked={{eq existingState _existingState.NEWFILE}}>
                                         <label for="existing" class='choose-large'><i class="fa fa-cloud-upload"></i> {{t "components.preprint-form-project-select.upload_preprint"}}</label>
                                     </div>
-                                    <div class="col-xs-3 text-center">
+                                    <div class="col-xs-6 col-sm-3 text-center">
                                         <input id='newfile' class="radio_item" onchange={{action 'changeExistingState' _existingState.EXISTINGFILE}} type="radio" checked={{eq existingState _existingState.EXISTINGFILE}}>
                                         <label class='choose-large' for="newfile"><i class="fa fa-th-list"></i>{{t "components.preprint-form-project-select.select_existing_file"}}</label>
                                     </div>

--- a/app/templates/components/preprint-form-project-select.hbs
+++ b/app/templates/components/preprint-form-project-select.hbs
@@ -86,7 +86,7 @@
                                             {{/if}}
                                         {{/if}}
                                         {{preprint-title-editor nodeTitle=nodeTitle titleValid=titleValid}}
-                                        <div class="row text-center m-v-md">
+                                        <div class="text-center m-v-md">
                                             <p>{{t "components.preprint-form-project-select.initiate_preprint_process"}}  </p>
                                             <button class="btn btn-primary" disabled={{or (and (eq convertOrCopy 'convert') (not convertProjectConfirmed))(not (and selectedFile titleValid))}} {{action (if (eq convertOrCopy 'convert') existingNodeExistingFile createComponentCopyFile) name}}>{{t "submit.body.save_continue"}}</button>
                                         </div>

--- a/app/templates/components/preprint-form-project-select.hbs
+++ b/app/templates/components/preprint-form-project-select.hbs
@@ -13,7 +13,7 @@
             {{else}}
                 {{#if userNodes}}
                     <div class="p-b-md">
-                        {{#power-select options=userNodes searchField='title' selected=selectedNode onchange=(action "nodeSelected") as |node|}}
+                        {{#power-select options=userNodes placeholder="Click to select" searchField='title' selected=selectedNode onchange=(action "nodeSelected") as |node|}}
                             {{get-ancestor-descriptor node}} <strong> {{node.title}}</strong>
                         {{/power-select}}
                     </div>

--- a/app/templates/components/preprint-form-project-select.hbs
+++ b/app/templates/components/preprint-form-project-select.hbs
@@ -5,7 +5,6 @@
 
             {{#if (not userNodesLoaded)}}
                 <div class="ball-pulse text-center">
-                    <!-- Leave these divs in -->
                     <div></div>
                     <div></div>
                     <div></div>

--- a/app/templates/components/preprint-form-project-select.hbs
+++ b/app/templates/components/preprint-form-project-select.hbs
@@ -2,9 +2,7 @@
     {{#preprint-form-section class="upload-section-block" allowOpen=true name='chooseProject' open=true}}
         {{preprint-form-header name='choose_project' selectedNode=selectedNode showValidationIndicator=false}}
         {{#preprint-form-body}}
-            <p class="text-muted">
-                {{t "components.preprint-form-project-select.existing_project_selector"}}
-            </p>
+
             {{#if (not userNodesLoaded)}}
                 <div class="ball-pulse text-center">
                     <!-- Leave these divs in -->
@@ -14,7 +12,7 @@
                 </div>
             {{else}}
                 {{#if userNodes}}
-                    <div class="p-b-md">
+                    <div class="m-t-sm">
                         {{#power-select options=userNodes placeholder="Click to select" searchField='title' selected=selectedNode onchange=(action "nodeSelected") as |node|}}
                             {{get-ancestor-descriptor node}} <strong> {{node.title}}</strong>
                         {{/power-select}}
@@ -23,6 +21,9 @@
                     <p class="m-t-md text-danger"> {{t "components.preprint-form-project-select.no_valid_existing_nodes"}} </p>
                 {{/if}}
             {{/if}}
+            <p class="text-muted text-smaller m-t-xs">
+                {{t "components.preprint-form-project-select.existing_project_selector"}}
+            </p>
         {{/preprint-form-body}}
     {{/preprint-form-section}}
     {{#if selectedNode}}

--- a/app/templates/submit.hbs
+++ b/app/templates/submit.hbs
@@ -33,10 +33,10 @@
                                         <div class={{currentState}}>
                                             {{#if (eq currentState _State.START)}}
                                                 <div class="row">
-                                                    <div class="col-xs-6 p-h-xl">
+                                                    <div class="col-xs-6">
                                                         <button class="btn btn-block btn-big" {{action 'changeInitialState' _State.NEW}}>Upload new preprint</button>
                                                     </div>
-                                                    <div class="col-xs-6  p-h-xl">
+                                                    <div class="col-xs-6">
                                                         <button class="btn btn-block btn-big" {{action 'changeInitialState' _State.EXISTING}}>Connect preprint to existing OSF project</button>
                                                     </div>
                                                 </div>

--- a/bower.json
+++ b/bower.json
@@ -11,7 +11,8 @@
     "bootstrap-sass": "^3.3.6",
     "toastr": "^2.1.2",
     "hint.css": "^2.3.2",
-    "jquery.tagsinput": "^1.3.6"
+    "jquery.tagsinput": "^1.3.6",
+    "loaders.css": "^0.1.2"
   },
   "resolutions": {
     "jquery": "~2.2.4"

--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -110,6 +110,8 @@ module.exports = function(defaults) {
     app.import(path.join(app.bowerDirectory, 'osf-style/vendor/prism/prism.css'));
     app.import(path.join(app.bowerDirectory, 'osf-style/page.css'));
     app.import(path.join(app.bowerDirectory, 'osf-style/css/base.css'));
+    app.import(path.join(app.bowerDirectory, 'loaders.css/loaders.min.css'));
+
 
     app.import(path.join(app.bowerDirectory, 'osf-style/img/cos-white2.png'), {
         destDir: 'img'


### PR DESCRIPTION
##Ticket
https://openscience.atlassian.net/browse/PREP-203

## Purpose
Polish for minor UI and design considerations for the OSF workflow. 

## Changes
Mainly layout changes affecting spacing, layout and narrow views 
Individual things changed: 
- Selecting an existing project has a placeholder to tell people what that dropdown is for
- Existing project shows a loader that is different than the existing one
- Texts on buttons wrap when needed on the initial upload step buttons and confirmation of are you sure you want to edit existing component buttons
- Borders and paddings are improved
- Buttons should properly collapse in narrow views (<768) 
- Authors table has more space (more of the remove button is visible) but full changes will need to be made in another PR to authors only
- Toggle buttons for upload vs choose file, new component vs current component etc are improved

## QA Notes
The changes listed above should be visible and layout should not break when changing window sizes. 