### PR TITLE
Feature/More Changes to Existing Workflow [PREP-142]

### DIFF
--- a/app/components/file-uploader.js
+++ b/app/components/file-uploader.js
@@ -134,6 +134,7 @@ export default Ember.Component.extend({
         preUpload(_, dropzone, file) {
             this.send('formatDropzoneAfterPreUpload');
             this.attrs.clearDownstreamFields('belowFile');
+            this.set('uploadInProgress', false);
             this.set('file', file);
             this.set('hasFile', true);
             this.set('callback', Ember.RSVP.defer());


### PR DESCRIPTION
# Purpose

Issue found by Allison.  Small issue: if a user selects "Connect to existing project" and then "Upload preprint," and then accidentally uploads a file that is already on the project, they will get an error message when attempting to "Save and continue" letting them know that the file already exists. If they then upload a new file and try to continue on, the "Save and continue" button remains grayed out and unclickable. It seems the upload box needs to be "refreshed" before the button is clickable again. This can be achieved by toggling to "Choose from existing file" then back to "Upload" in the Choose File section, but the "Save and continue" button should be clickable as soon as the new file is uploaded (and all other sections filled out correctly).

# Changes

Resets state properly when preuploading a file.