### PR TITLE
Feature/QA fix, Importing Existing Contributors

### DIFF
--- a/app/components/preprint-form-authors.js
+++ b/app/components/preprint-form-authors.js
@@ -59,9 +59,8 @@ export default CpPanelBodyComponent.extend({
         // Adds all contributors from parent project to current component as long as they are not current contributors
         addContributorsFromParentProject() {
             this.set('parentContributorsAdded', true);
-            var parentNode = this.get('parentNode');
             var contributorsToAdd = Ember.A();
-            parentNode.get('contributors').toArray().forEach(contributor => {
+            this.get('parentContributors').toArray().forEach(contributor => {
                 if (this.get('currentContributorIds').indexOf(contributor.get('userId')) === -1) {
                     contributorsToAdd.push({
                         permission: contributor.get('permission'),

--- a/app/controllers/submit.js
+++ b/app/controllers/submit.js
@@ -122,7 +122,7 @@ export default Ember.Controller.extend(BasicsValidations, NodeActionsMixin, Tagg
     // Validation rules for form sections
 
     // In order to advance from upload state, node and selectedFile must have been defined, and nodeTitle must be set.
-    uploadValid: Ember.computed.and('node', 'selectedFile', 'nodeTitle'),
+    uploadValid: Ember.computed.and('node', 'selectedFile', 'nodeTitle', 'fileAndNodeLocked'),
     abstractValid: Ember.computed.alias('validations.attrs.basicsAbstract.isValid'),
     doiValid: Ember.computed.alias('validations.attrs.basicsDOI.isValid'),
     // Basics fields that are being validated are abstract and doi (title validated in upload section). If validation added for other fields, expand basicsValid definition.

--- a/app/controllers/submit.js
+++ b/app/controllers/submit.js
@@ -75,6 +75,7 @@ export default Ember.Controller.extend(BasicsValidations, NodeActionsMixin, Tagg
     basicsSaveState: false, // True temporarily when changes have been saved in basics section
     authorsSaveState: false, // True temporarily when changes have been saved in authors section
     parentNode: null, // If component created, parentNode will be defined
+    parentContributors: Ember.A(),
     convertProjectConfirmed: false, // User has confirmed they want to convert their existing OSF project into a preprint,
     convertOrCopy: null, // Will either be 'convert' or 'copy' depending on whether user wants to use existing component or create a new component.
 
@@ -166,6 +167,13 @@ export default Ember.Controller.extend(BasicsValidations, NodeActionsMixin, Tagg
         let contributors = Ember.A();
         loadAll(node, 'contributors', contributors).then(()=>
              this.set('contributors', contributors));
+    }),
+
+    getParentContributors: Ember.observer('parentNode', function() {
+        let parent = this.get('parentNode');
+        let contributors = Ember.A();
+        loadAll(parent, 'contributors', contributors).then(()=>
+             this.set('parentContributors', contributors));
     }),
 
     isAdmin: Ember.computed('node', function() {

--- a/app/templates/submit.hbs
+++ b/app/templates/submit.hbs
@@ -161,6 +161,7 @@
                                 </p>
                                 {{preprint-form-authors
                                     contributors=contributors
+                                    parentContributors=parentContributors
                                     node=node
                                     isAdmin=isAdmin
                                     canEdit=canEdit


### PR DESCRIPTION
# Purpose

Not all contributors were being added from parentProject.  Fetching contributors from parentProject was relying on contributors already in store, fetched by `parentNode.get('contributors')`, instead of a clean loadAll parent node contributors.

# Changes
 
Changes the way parent contributors are loaded.