### PR TITLE
[Hotfix] Reset userNodesLoaded Field

### DIFF
--- a/app/controllers/submit.js
+++ b/app/controllers/submit.js
@@ -111,6 +111,7 @@ export default Ember.Controller.extend(BasicsValidations, NodeActionsMixin, Tagg
             parentNode: null,
             convertProjectConfirmed: false,
             basicsAbstract: null,
+            userNodesLoaded: false,
         }));
     },
 


### PR DESCRIPTION
# Purpose

When userNodes initially loading, there is a spinner.  When you navigate away from page, and then return to add preprints page, state wasn't reset, so error message displayed that there were no user nodes that you could turn into a preprint.

# Changes
Adds userNodesLoaded field to the list of fields that are reset when navigating away and returning to Add Preprints page.