### PR TITLE
Feature/Version Changes [PREP-144]

### DIFF
--- a/app/templates/components/supplementary-file-browser.hbs
+++ b/app/templates/components/supplementary-file-browser.hbs
@@ -8,9 +8,7 @@
     </div>
     <div class="col-xs-4 text-nowrap">
         <div class="pull-right">
-            {{#if (and hasAdditionalFiles (not-eq selectedFile.id preprint.primaryFile.id))}}
-                <a class="btn btn-default btn-sm" href={{selectedFile.links.download}}>{{t "content.share.download_file"}}</a>
-            {{/if}}
+            <a class="btn btn-default btn-sm" href={{selectedFile.links.download}}> {{if (eq selectedFile.id preprint.primaryFile.id) (t "content.share.download_preprint") (t "content.share.download_file")}} </a>
             <span class="p-sm"> {{t "content.version"}}: {{selectedFile.currentVersion}}</span>
         </div>
     </div>

--- a/app/templates/content.hbs
+++ b/app/templates/content.hbs
@@ -35,8 +35,8 @@
                     {{#liquid-spacer growDuration=250 growWidth=false}}
                         <div class="p-sm osf-box-lt clearfix">{{!SHARE ROW}}
                             <div class="" id="download_project clearfix">
-                                <a class="btn btn-primary" href={{model.primaryFile.links.download}} onbeforeclick={{action 'click' 'link' 'Content - Download'}}>{{t "content.share.download"}}</a>
-                                <span class="p-sm">{{t "content.share.downloads"}}: {{activeFile.extra.downloads}}</span>
+                                <a class="btn btn-primary" href={{model.primaryFile.links.download}} onbeforeclick={{action 'click' 'link' 'Content - Download'}}>{{t "content.share.download_preprint"}}</a>
+                                <span class="p-sm">{{t "content.share.downloads"}}: {{model.primaryFile.extra.downloads}}</span>
                                 <span class="p-xs pull-right">
                                     <a class="m-r-xs text-smaller" href={{twitterHref}} onclick={{action 'shareLink' twitterHref 'Twitter' 'tweet'}}>{{fa-icon 'twitter-square' size=2 }}</a>
                                     <a class="m-r-xs text-smaller" href={{facebookHref}} onclick={{action 'shareLink' facebookHref 'Facebook' 'share'}}>{{fa-icon 'facebook-square' size=2 }}</a>

--- a/tests/integration/components/supplementary-file-browser-test.js
+++ b/tests/integration/components/supplementary-file-browser-test.js
@@ -30,7 +30,7 @@ test('it renders', function(assert) {
 
     this.render(hbs`{{supplementary-file-browser preprint=preprint}}`);
 
-    assert.equal(this.$().text().trim(), 'Version:');
+    assert.equal(this.$().text().trim().replace(/\s/g, ""), 'DownloadpreprintVersion:');
 
     //  this.on('changeFile', function() {});
 });


### PR DESCRIPTION
# Purpose

Fix for https://openscience.atlassian.net/browse/PREP-144

# Changes
Errors pointed out by Todd.

- Download button at the top says 'Download preprint'. 
- Download counts at top reflect primary file downloads, instead of selected file
- Download links at bottom say 'Download preprint' if primary file. 'Download file' otherwise