### PR TITLE
Remove Google Analytics inline content injection during production build

### DIFF
--- a/app/templates/application.hbs
+++ b/app/templates/application.hbs
@@ -8,4 +8,3 @@
 {{osf-footer}}
 {{osf-copyright class='text-center'}}
 {{osf-mode-footer}}
-j

--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -40,19 +40,6 @@ module.exports = function(defaults) {
                     <script src="https://cdn.ravenjs.com/3.5.1/ember/raven.min.js"></script>
                     <script>Raven.config("${config.sentryDSN}", {}).install();</script>`
             },
-            'google-analytics': {
-                enabled: useCdn,
-                content: `
-                    <script>
-                    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-                    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-                    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-                    })(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
-
-                    ga('create', '${config.googleID}', 'auto');
-                    //ga('send', 'pageview');
-                    </script>`
-            },
             cdn: {
                 enabled: useCdn,
                 content: `


### PR DESCRIPTION
This is no longer needed since we're handling it via [ember-metrics](/poteto/ember-metrics/blob/master/addon/metrics-adapters/google-analytics.js#L32). The duplicate script overrides the GA script from ember-metrics and shows the ID as undefined.