### PR TITLE
[Hotfix] basicsAbstract Field Not Resetting

### DIFF
--- a/app/components/file-uploader.js
+++ b/app/components/file-uploader.js
@@ -133,6 +133,7 @@ export default Ember.Component.extend({
                 this.set('uploadInProgress', true);
             }
             let node = this.get('node');
+            this.set('basicsAbstract', this.get('node.description') || null);
             let currentTitle = node.get('title');
             if (node.get('title') !== this.get('nodeTitle')) {
                 node.set('title', this.get('nodeTitle'));

--- a/app/controllers/submit.js
+++ b/app/controllers/submit.js
@@ -408,6 +408,7 @@ export default Ember.Controller.extend(BasicsValidations, NodeActionsMixin, Tagg
         existingNodeExistingFile() {
             // Upload case for using existing node and existing file for the preprint.  If title has been edited, updates title.
             let node = this.get('node');
+            this.set('basicsAbstract', this.get('node.description') || null);
             if (node.get('title') !== this.get('nodeTitle')) {
                 let currentTitle = node.get('title');
                 node.set('title', this.get('nodeTitle'));


### PR DESCRIPTION
# Purpose

The basicsAbstract field is the pending abstract for your preprint.  When you select an existing node to connect to your preprint, the basicsAbstract field is populated with the description stored on the node.  In the node dropdown, if you selected one node, and then changed your mind and selected another, the basicsAbstract field was showing up as the abstract from the first node and not the current node.

# Changes
When creating a preprint using an existing node, ensures that the basicsAbstract field is equal to the abstract on that existing node.