### PR TITLE
Feature/Preprint File inside Folder [PREP-241]

### DIFF
--- a/app/components/supplementary-file-browser.js
+++ b/app/components/supplementary-file-browser.js
@@ -30,17 +30,13 @@ export default Ember.Component.extend(Analytics, {
                 this.set('provider', providers.findBy('name', 'osfstorage'));
                 return loadAll(this.get('provider'), 'files', this.get('files'), {'page[size]': 50});
             })
-            .then(() => {
-                let pf = this.get('files').findBy('id', this.get('preprint.primaryFile.id'));
-                if (pf) {
-                    this.get('files').removeObject(pf);
-                    this.set('primaryFile', pf);
-                }
-
+            .then(() => this.get('preprint').get('primaryFile'))
+            .then((pf) => {
+                this.get('files').removeObject(pf);
+                this.set('primaryFile', pf);
                 this.set('selectedFile', this.get('primaryFile'));
                 this.set('files', [this.get('primaryFile')].concat(this.get('files')));
             });
-
     }.observes('preprint'),
 
     init() {

--- a/app/templates/components/supplementary-file-browser.hbs
+++ b/app/templates/components/supplementary-file-browser.hbs
@@ -19,7 +19,7 @@
         {{#liquid-bind (slice-array files startIndex endIndex) use=scrollAnim as |list|}}
             {{#each list as |supplement index|}}
                 {{#if (eq supplement.kind "folder")}}
-                    <a href={{concat node.links.html 'files'}} class="hint--bottom col-xs-2 p-md box m-b-xl" aria-label={{supplement.name}}>
+                    <a href={{concat node.links.html 'files'}} target="_blank" class="hint--bottom col-xs-2 p-md box m-b-xl" aria-label={{supplement.name}}>
                         <i class="fa fa-folder fa-2x p-b-xs" aria-hidden="true"></i>
                     </a>
                 {{else}}

--- a/app/templates/components/supplementary-file-browser.hbs
+++ b/app/templates/components/supplementary-file-browser.hbs
@@ -19,7 +19,7 @@
         {{#liquid-bind (slice-array files startIndex endIndex) use=scrollAnim as |list|}}
             {{#each list as |supplement index|}}
                 {{#if (eq supplement.kind "folder")}}
-                    <a href={{preprint.links.html}} class="hint--bottom col-xs-2 p-md box m-b-xl" aria-label={{supplement.name}}>
+                    <a href={{concat node.links.html 'files'}} class="hint--bottom col-xs-2 p-md box m-b-xl" aria-label={{supplement.name}}>
                         <i class="fa fa-folder fa-2x p-b-xs" aria-hidden="true"></i>
                     </a>
                 {{else}}


### PR DESCRIPTION
# Ticket 
https://openscience.atlassian.net/browse/PREP-241

# Purpose
If preprint file is stored inside a folder under OSF storage, it does not load.  Currently, the only files that are displaying are top level files.

# Changes
1) Makes a separate request to load the preprint file from the preprint relationship instead of searching through the top-level files for a match.  

2) When clicking on a folder, links to the OSF node files page.  Currently, the page links back to itself.

# Notes for Reviewers

The hierarchy in the UI will not be correct when the preprint is stored inside a file, but I think this is fine, esp because this file gets a special 'Primary' indication, showing that it's different than the others.  I am showing this preprint file alongside all the top-level files and folders, even if that preprint file is actually stored inside a folder.  I did this because this isn't supposed to be a file tree, and I don't think the intent is for them to comb through multiple levels of folders to find their preprint.  

![screen shot 2016-11-22 at 12 07 18 pm](https://cloud.githubusercontent.com/assets/9755598/20533815/dbee370e-b0ac-11e6-9d7c-1169a6cf404b.png)
