### PR TITLE
Feature/Rewrite get-ancestor-descriptor helper [PREP-257]

### DIFF
--- a/app/helpers/get-ancestor-descriptor.js
+++ b/app/helpers/get-ancestor-descriptor.js
@@ -1,42 +1,51 @@
 import Ember from 'ember';
 
-// Formats titles similar to the way they're displayed in the dashboard.  For example, Root Name / ... / Parent Name / Node Name.
+function fetchIdFromRelationshipLink(node, relationship) {
+    // Private node ids can be accessed under initializedRelationships.
+    if (node) {
+        let relationships = node._internalModel._relationships.initializedRelationships[relationship];
+        if (relationships && relationships.link) {
+            return relationships.link.split('nodes')[1].replace(/\//g, '');
+        }
+    }
+   return undefined;
+}
+
+function fetchTitle(node, relationship) {
+    // Fetches parent or root title.  If null, marks 'Private'.
+    let title = node.get(`${relationship}.title`);
+    if (typeof title === 'undefined') {
+        title = 'Private';
+    }
+    return title;
+
+}
+
 export function getAncestorDescriptor(params/*, hash*/) {
-    var node = params[0];
-    var nodeId = node.get('id');
-    var rootId = node.get('root.id');
-    var parentId = node.get('parent.id');
-    var rootDescriptor;
+    // Formats titles similar to the way they're displayed in the dashboard.  For example, Root Name / ... / Parent Name / Node Name.
+    let node = params[0];
+    let nodeId = node.get('id');
+    let rootId = node.get('root.id');
+    let parentId = node.get('parent.id')
 
-    if (typeof rootId !== 'undefined') {
-        if (typeof parentId !== 'undefined') {
-            if (parentId === rootId) {
-                rootDescriptor = node.get('root.title') + ' / ';
-            } else {
-                if (node.get('parent.parent.id') === rootId) {
-                    rootDescriptor = node.get('root.title') + ' / ' + node.get('parent.title') + ' / ';
-                } else {
-                    rootDescriptor = node.get('root.title') + ' /.../ ' + node.get('parent.title') + ' / ';
-                }
-            }
-        } else {
-            if (rootId === nodeId) {
-                rootDescriptor = '';
-            } else {
-                rootDescriptor = node.get('root.title') + '/Private/ ';
-            }
-        }
-    } else {
-        if (typeof parentId !== 'undefined') {
-            if (node.get('parent.parent.id')) {
-                rootDescriptor = 'Private / ... / ' + node.get('parent.title') + ' / ';
+    if (typeof rootId === 'undefined') rootId = fetchIdFromRelationshipLink(node, 'root');
+    if (typeof parentId === 'undefined') parentId = fetchIdFromRelationshipLink(node, 'parent');
 
-            } else {
-                rootDescriptor = 'Private / ' + node.get('parent.title') + ' / ';
-            }
-        } else {
-            rootDescriptor = '';
-        }
+    let parentTitle = fetchTitle(node, 'parent');
+    let rootTitle = fetchTitle(node, 'root');
+
+    let parent = node.get('parent').content;
+    let parentParentId = fetchIdFromRelationshipLink(parent, 'parent');
+
+    let rootDescriptor;
+    if (rootId === nodeId) { // One level
+        rootDescriptor = '';
+    } else if (rootId === parentId) { // Two levels
+        rootDescriptor = parentTitle + ' / '
+    } else if (rootId === parentParentId) { // Three levels
+        rootDescriptor = rootTitle + ' / ' + parentTitle + ' / '
+    } else { // Four + levels
+        rootDescriptor = rootTitle + ' / ... / ' + parentTitle + ' / '
     }
 
     return rootDescriptor;

--- a/app/helpers/get-ancestor-descriptor.js
+++ b/app/helpers/get-ancestor-descriptor.js
@@ -27,7 +27,7 @@ export function getAncestorDescriptor(params/*, hash*/) {
     let nodeId = node.get('id');
     let rootId = node.get('root.id');
     let parentId = node.get('parent.id');
-    let parent = node.get('parent').content;
+    let parent = (node.get('parent') instanceof Ember.ObjectProxy) ? node.get('parent.content') : node.get('parent');
     let parentParentId = parent ? parent.get('parent.id') : undefined;
 
     if (typeof rootId === 'undefined') rootId = fetchIdFromRelationshipLink(node, 'root');

--- a/app/helpers/get-ancestor-descriptor.js
+++ b/app/helpers/get-ancestor-descriptor.js
@@ -1,7 +1,8 @@
 import Ember from 'ember';
 
 function fetchIdFromRelationshipLink(node, relationship) {
-    // Private node ids can be accessed under initializedRelationships.
+    // If id is not embedded in request, Private node ids can be accessed under initializedRelationships.
+    // May still return undefined if parent, for example, does not exist.
     if (node) {
         let relationships = node._internalModel._relationships.initializedRelationships[relationship];
         if (relationships && relationships.link) {

--- a/app/helpers/get-ancestor-descriptor.js
+++ b/app/helpers/get-ancestor-descriptor.js
@@ -4,9 +4,9 @@ function fetchIdFromRelationshipLink(node, relationship) {
     // If id is not embedded in request, Private node ids can be accessed under initializedRelationships.
     // May still return undefined if parent, for example, does not exist.
     if (node) {
-        let relationships = node._internalModel._relationships.initializedRelationships[relationship];
-        if (relationships && relationships.link) {
-            return relationships.link.split('nodes')[1].replace(/\//g, '');
+        let initializedRelationship = node._internalModel._relationships.initializedRelationships[relationship];
+        if (initializedRelationship && initializedRelationship.link) {
+            return initializedRelationship.link.split('nodes')[1].replace(/\//g, '');
         }
     }
     return undefined;

--- a/app/helpers/get-ancestor-descriptor.js
+++ b/app/helpers/get-ancestor-descriptor.js
@@ -27,15 +27,15 @@ export function getAncestorDescriptor(params/*, hash*/) {
     let nodeId = node.get('id');
     let rootId = node.get('root.id');
     let parentId = node.get('parent.id');
+    let parent = node.get('parent').content;
+    let parentParentId = parent ? parent.get('parent.id') : undefined;
 
     if (typeof rootId === 'undefined') rootId = fetchIdFromRelationshipLink(node, 'root');
     if (typeof parentId === 'undefined') parentId = fetchIdFromRelationshipLink(node, 'parent');
+    if (typeof parentParentId === 'undefined') parentParentId = fetchIdFromRelationshipLink(parent, 'parent');
 
     let parentTitle = fetchTitle(node, 'parent');
     let rootTitle = fetchTitle(node, 'root');
-
-    let parent = node.get('parent').content;
-    let parentParentId = fetchIdFromRelationshipLink(parent, 'parent');
 
     let rootDescriptor;
     if (rootId === nodeId) { // One level

--- a/app/helpers/get-ancestor-descriptor.js
+++ b/app/helpers/get-ancestor-descriptor.js
@@ -8,7 +8,7 @@ function fetchIdFromRelationshipLink(node, relationship) {
             return relationships.link.split('nodes')[1].replace(/\//g, '');
         }
     }
-   return undefined;
+    return undefined;
 }
 
 function fetchTitle(node, relationship) {
@@ -18,7 +18,6 @@ function fetchTitle(node, relationship) {
         title = 'Private';
     }
     return title;
-
 }
 
 export function getAncestorDescriptor(params/*, hash*/) {
@@ -26,7 +25,7 @@ export function getAncestorDescriptor(params/*, hash*/) {
     let node = params[0];
     let nodeId = node.get('id');
     let rootId = node.get('root.id');
-    let parentId = node.get('parent.id')
+    let parentId = node.get('parent.id');
 
     if (typeof rootId === 'undefined') rootId = fetchIdFromRelationshipLink(node, 'root');
     if (typeof parentId === 'undefined') parentId = fetchIdFromRelationshipLink(node, 'parent');
@@ -41,13 +40,12 @@ export function getAncestorDescriptor(params/*, hash*/) {
     if (rootId === nodeId) { // One level
         rootDescriptor = '';
     } else if (rootId === parentId) { // Two levels
-        rootDescriptor = parentTitle + ' / '
+        rootDescriptor = parentTitle + ' / ';
     } else if (rootId === parentParentId) { // Three levels
-        rootDescriptor = rootTitle + ' / ' + parentTitle + ' / '
+        rootDescriptor = rootTitle + ' / ' + parentTitle + ' / ';
     } else { // Four + levels
-        rootDescriptor = rootTitle + ' / ... / ' + parentTitle + ' / '
+        rootDescriptor = rootTitle + ' / ... / ' + parentTitle + ' / ';
     }
-
     return rootDescriptor;
 }
 

--- a/tests/unit/helpers/get-ancestor-descriptor-test.js
+++ b/tests/unit/helpers/get-ancestor-descriptor-test.js
@@ -8,20 +8,24 @@ module('Unit | Helper | get ancestor descriptor');
 test('One, two, three, and four-level hierarchies', function(assert) {
     var root = Ember.Object.create({
         'id': '12345',
-        'title': "Great-Grandparent",
-        'root': root,
+        'title': 'Great-Grandparent',
+        'root': Ember.Object.create({
+            'id': '12345',
+            'title': 'Great-Grandparent'
+        }),
         '_internalModel': {
             '_relationships': {
                 'initializedRelationships': {
 
                 }
             }
-        }
+        },
+        parent: null
     });
 
     var grandparent = Ember.Object.create({
         'id': '67890',
-        'title': "Grandparent",
+        'title': 'Grandparent',
         'parent': root,
         'root': root
     });

--- a/tests/unit/helpers/get-ancestor-descriptor-test.js
+++ b/tests/unit/helpers/get-ancestor-descriptor-test.js
@@ -6,7 +6,7 @@ import Ember from 'ember';
 module('Unit | Helper | get ancestor descriptor');
 
 test('One, two, three, and four-level hierarchies', function(assert) {
-    var root = Ember.Object.create({
+    let root = Ember.Object.create({
         'id': '12345',
         'title': 'Great-Grandparent',
         'root': Ember.Object.create({
@@ -23,20 +23,20 @@ test('One, two, three, and four-level hierarchies', function(assert) {
         parent: null
     });
 
-    var grandparent = Ember.Object.create({
+    let grandparent = Ember.Object.create({
         'id': '67890',
         'title': 'Grandparent',
         'parent': root,
         'root': root
     });
 
-    var parent = Ember.Object.create({
+    let parent = Ember.Object.create({
         'id': 'abcde',
         'title': 'Parent',
         'parent': grandparent,
         'root': root
     });
-    var node = Ember.Object.create({
+    let node = Ember.Object.create({
         'id': 'fghij',
         'root': root,
         'parent': parent,
@@ -54,4 +54,26 @@ test('One, two, three, and four-level hierarchies', function(assert) {
 
     let describeGreatGrandparent = getAncestorDescriptor([root]);
     assert.equal(describeGreatGrandparent, '');
+});
+
+test('Test private parent', function(assert) {
+    let child = Ember.Object.create({
+        id: 'abcde',
+        title: 'child',
+        '_internalModel': {
+            '_relationships': {
+                'initializedRelationships': {
+                    'root': {
+                        'link': '/nodes/12345/'
+                    },
+                    'parent': {
+                        'link': '/nodes/12345/'
+                    }
+                }
+            }
+        },
+    });
+
+    let result = getAncestorDescriptor([child]);
+    assert.equal(result, 'Private / ');
 });

--- a/tests/unit/helpers/get-ancestor-descriptor-test.js
+++ b/tests/unit/helpers/get-ancestor-descriptor-test.js
@@ -9,20 +9,39 @@ module('Unit | Helper | get ancestor descriptor');
 test('it works', function(assert) {
     var root = Ember.Object.create({
         'id': '12345',
-        'title': "Root title"
+        'title': "Great-Grandparent",
+        'root': root
     });
+
+    var grandparent = Ember.Object.create({
+        'id': '67890',
+        'title': "Grandparent",
+        'parent': root,
+        'root': root
+    });
+
     var parent = Ember.Object.create({
         'id': 'abcde',
-        'title': 'Parent title',
-        'parent': root
+        'title': 'Parent',
+        'parent': grandparent,
+        'root': root
     });
     var node = Ember.Object.create({
         'id': 'fghij',
         'root': root,
         'parent': parent,
-        'title': 'Node title'
+        'title': 'Child'
     });
-    let result = getAncestorDescriptor([node]);
-    assert.equal(result, 'Root title / Parent title / ');
 
+    let describeNode = getAncestorDescriptor([node]);
+    assert.equal(describeNode, 'Great-Grandparent / ... / Parent / ');
+
+    let describeParent = getAncestorDescriptor([parent]);
+    assert.equal(describeParent, 'Great-Grandparent / Grandparent /');
+
+    let describeGrandparent = getAncestorDescriptor([grandparent]);
+    assert.equal(describeGrandparent, 'Great-Grandparent');
+
+    let describeGreatGrandparent = getAncestorDescriptor([root]);
+    assert.equal(describeGreatGrandparent, '');
 });

--- a/tests/unit/helpers/get-ancestor-descriptor-test.js
+++ b/tests/unit/helpers/get-ancestor-descriptor-test.js
@@ -5,12 +5,18 @@ import Ember from 'ember';
 
 module('Unit | Helper | get ancestor descriptor');
 
-// Replace this with your real tests.
-test('it works', function(assert) {
+test('One, two, three, and four-level hierarchies', function(assert) {
     var root = Ember.Object.create({
         'id': '12345',
         'title': "Great-Grandparent",
-        'root': root
+        'root': root,
+        '_internalModel': {
+            '_relationships': {
+                'initializedRelationships': {
+
+                }
+            }
+        }
     });
 
     var grandparent = Ember.Object.create({
@@ -37,10 +43,10 @@ test('it works', function(assert) {
     assert.equal(describeNode, 'Great-Grandparent / ... / Parent / ');
 
     let describeParent = getAncestorDescriptor([parent]);
-    assert.equal(describeParent, 'Great-Grandparent / Grandparent /');
+    assert.equal(describeParent, 'Great-Grandparent / Grandparent / ');
 
     let describeGrandparent = getAncestorDescriptor([grandparent]);
-    assert.equal(describeGrandparent, 'Great-Grandparent');
+    assert.equal(describeGrandparent, 'Great-Grandparent / ');
 
     let describeGreatGrandparent = getAncestorDescriptor([root]);
     assert.equal(describeGreatGrandparent, '');


### PR DESCRIPTION
# Ticket 
https://openscience.atlassian.net/browse/PREP-257
❗️ Requires that https://github.com/CenterForOpenScience/ember-osf/pull/148 is merged.

# Purpose

On the `Add Preprint` page, you have the option to connect your preprint to an existing project.   The `get-ancestor-descriptor` helper allows us to format the projects in the project dropdown similarly to how they are formatted in the dashboard, with a hierarchy, so users can distinguish between similarly-named projects.  However, there are some errors in the logic, particularly when a project in the hierarchy is private.

![screen shot 2016-11-28 at 8 21 06 am](https://cloud.githubusercontent.com/assets/9755598/20669856/49d5d3e4-b544-11e6-8d4d-3012318e05e1.png)

# Changes
- Rewrites get-ancestor-descriptor so logic is easier to follow.
  - If parentId, rootId, parentparentId's are undefined  (case if private or does not exist), attempts to pull id from relationship link (in which case it is private). If link DNE, then relationship DNE.
  - Defines parentId, rootId, parentParentId, parentTitle, and rootTitle first.  If parentTitle or rootTitle DNE, changes to 'Private'
  - Then checks if node is one level, two levels, three levels, or four+ levels deep and the returns the appropriate ancestor descriptor accordingly.
- Better handles private projects
- Adds better tests to get-ancestor-descriptor

# For QA

The way dropdown is populated was rewritten, so you should re-test whatever you tested before for this.  Most behavior should be the same, but there were errors in the way that 'private' projects in the hierarchy were being displayed, mostly in the number of levels you would see.

Errors that have been fixed:

- Create a project "Parent", and then a component inside this project, "Child".  Then add another admin contributor to `Parent` and remove yourself.  So you only have access to "Child", but not it's ancestor, "Parent".  Project dropdown should read: ` Private / Child `.  Prior to this fix, it read only ` Child `, leading you to think "Child" was top-level.

- Create four levels of projects "Apple" > "Banana" > "Cantaloupe" > "Date".  Remove yourself as a contributor from "Apple" and "Cantaloupe".  Because you are still a contributor on "Banana", and therefore can access 'Cantaloupe',  dropdown for 'Date', reads `Private / ... / Cantaloupe / Date`.  Old version was `Private / Cantaloupe / Date`, which is incorrect, because grandparent of 'Date' is not private, and items in the hierarchy are missing.



