### PR TITLE
Feature/Redirect to Resource Deleted if 410 [PREP-260]

### DIFF
--- a/app/controllers/resource-deleted.js
+++ b/app/controllers/resource-deleted.js
@@ -1,0 +1,6 @@
+import Ember from 'ember';
+import Analytics from '../mixins/analytics';
+
+export default Ember.Controller.extend(Analytics, {
+    theme: Ember.inject.service(),
+});

--- a/app/locales/en/translations.js
+++ b/app/locales/en/translations.js
@@ -134,6 +134,13 @@ export default {
         },
         go_to: `Go to {{brand}}`
     },
+    'resource-deleted': {
+        heading: `Resource deleted`,
+        paragraph: {
+            line1: `User has deleted this content. If this should not have occurred and the issue persists, please report it to  `,
+        },
+        go_to: `Go to {{brand}}`
+    },
     submit: {
         add_heading: `Add Preprint`,
         edit_heading: `Edit Preprint`,

--- a/app/router.js
+++ b/app/router.js
@@ -35,6 +35,7 @@ Router.map(function() {
         this.route('page-not-found');
     });
     this.route('forbidden');
+    this.route('resource-deleted');
 });
 
 export default Router;

--- a/app/routes/content.js
+++ b/app/routes/content.js
@@ -135,23 +135,27 @@ export default Ember.Route.extend(Analytics, ResetScrollMixin, SetupSubmitContro
     },
     actions: {
         error(error, transition) {
-            const slug = transition.params[transition.targetName].preprint_id;
-
-            if (slug.length === 5) {
-                window.location.href = [
-                    window.location.origin,
-                    slug
-                ].join('/');
+            if (error && error.errors && Ember.isArray(error.errors) && error.errors[0].detail === 'The requested node is no longer available.') {
+                this.intermediateTransitionTo('resource-deleted'); // Node containing preprint has been deleted. 410 Gone.
             } else {
-                const path = ['', 'preprints'];
+                const slug = transition.params[transition.targetName].preprint_id;
 
-                if (this.get('theme.isProvider'))
-                    path.push(this.get('theme.id'));
+                if (slug.length === 5) {
+                    window.location.href = [
+                        window.location.origin,
+                        slug
+                    ].join('/');
+                } else {
+                    const path = ['', 'preprints'];
 
-                path.push(slug);
+                    if (this.get('theme.isProvider'))
+                        path.push(this.get('theme.id'));
 
-                window.history.replaceState({}, 'preprints', path.join('/'));
-                this.intermediateTransitionTo('page-not-found');
+                    path.push(slug);
+
+                    window.history.replaceState({}, 'preprints', path.join('/'));
+                    this.intermediateTransitionTo('page-not-found');
+                }
             }
         }
     }

--- a/app/routes/resource-deleted.js
+++ b/app/routes/resource-deleted.js
@@ -1,0 +1,6 @@
+import Ember from 'ember';
+import ResetScrollMixin from '../mixins/reset-scroll';
+import Analytics from '../mixins/analytics';
+
+export default Ember.Route.extend(Analytics, ResetScrollMixin, {
+});

--- a/app/styles/app.scss
+++ b/app/styles/app.scss
@@ -430,6 +430,13 @@ ul.preprints-block-list {
     border-bottom: 1px solid #d6dbdc;
 }
 
+/* Gone page */
+.preprint-410 {
+    padding: 120px 0 120px 0;
+    background-color: #ecf2f3;
+    border-bottom: 1px solid #d6dbdc;
+}
+
 /* Usefulness of the portions of code below is doubtful, mixed with critical and unused. TODO: Go through and clean up unused code */
 
 

--- a/app/templates/resource-deleted.hbs
+++ b/app/templates/resource-deleted.hbs
@@ -1,0 +1,27 @@
+{{title 'Resource Deleted'}}
+
+<div class="preprint-410">
+    <div class="container">
+        <div class="row">
+            <div class="col-xs-12">
+                <h1>{{t "resource-deleted.heading"}} </h1>
+                <p>
+                    <span>{{t "resource-deleted.paragraph.line1"}}</span>
+                    <a href="mailto:{{if theme.isProvider theme.provider.emailSupport "support@osf.io"}}"
+                       onbeforeclick={{action "click" "link" "Resource Deleted - Support"}}>
+                        {{if (and theme.isProvider theme.provider.emailSupport) theme.provider.emailSupport "support@osf.io"}}
+                    </a>
+                </p>
+                {{#if theme.isProvider}}
+                    {{#link-to "provider.index" theme.id class="btn btn-primary m-t-md" invokeAction=(action "click" "link" "Resource Deleted - Go to Index")}}
+                        {{t "resource-deleted.go_to" brand=(t "global.provider_brand" name=theme.provider.name)}}
+                    {{/link-to}}
+                {{else}}
+                    {{#link-to "index" class="btn btn-primary m-t-md" invokeAction=(action "click" "link" "Resource Deleted - Go to Index")}}
+                        {{t "resource-deleted.go_to" brand=(t "global.brand")}}
+                    {{/link-to}}
+                {{/if}}
+            </div>
+        </div>
+    </div>
+</div>

--- a/tests/unit/controllers/resource-deleted-test.js
+++ b/tests/unit/controllers/resource-deleted-test.js
@@ -1,0 +1,12 @@
+import { moduleFor, test } from 'ember-qunit';
+
+moduleFor('controller:resource-deleted', 'Unit | Controller | resource deleted', {
+  // Specify the other units that are required for this test.
+  // needs: ['controller:foo']
+});
+
+// Replace this with your real tests.
+test('it exists', function(assert) {
+  let controller = this.subject();
+  assert.ok(controller);
+});

--- a/tests/unit/controllers/resource-deleted-test.js
+++ b/tests/unit/controllers/resource-deleted-test.js
@@ -2,7 +2,10 @@ import { moduleFor, test } from 'ember-qunit';
 
 moduleFor('controller:resource-deleted', 'Unit | Controller | resource deleted', {
   // Specify the other units that are required for this test.
-  // needs: ['controller:foo']
+    needs: [
+        'service:metrics',
+        'service:theme'
+    ]
 });
 
 // Replace this with your real tests.

--- a/tests/unit/routes/resource-deleted-test.js
+++ b/tests/unit/routes/resource-deleted-test.js
@@ -1,0 +1,11 @@
+import { moduleFor, test } from 'ember-qunit';
+
+moduleFor('route:resource-deleted', 'Unit | Route | resource deleted', {
+  // Specify the other units that are required for this test.
+  // needs: ['controller:foo']
+});
+
+test('it exists', function(assert) {
+  let route = this.subject();
+  assert.ok(route);
+});

--- a/tests/unit/routes/resource-deleted-test.js
+++ b/tests/unit/routes/resource-deleted-test.js
@@ -2,7 +2,7 @@ import { moduleFor, test } from 'ember-qunit';
 
 moduleFor('route:resource-deleted', 'Unit | Route | resource deleted', {
   // Specify the other units that are required for this test.
-  // needs: ['controller:foo']
+  needs: ['service:metrics']
 });
 
 test('it exists', function(assert) {


### PR DESCRIPTION
# Ticket 

https://openscience.atlassian.net/browse/PREP-260

# Purpose

If you delete a node that contains a preprint, when you try to navigate to that preprint it will get stuck in an infinite loop.

# Changes

- Adds resource-deleted route (with GA tracking and branding-specific)
- Redirects to resource-deleted route if the request to fetch the node returns a 410 Gone (actually checking error message details, can't get the status code Ember-side)
 - Does not modify url in location bar when redirects - want to see which url had error

# Screenshots - OSF and Psyarxiv

![screen shot 2016-11-29 at 4 20 16 pm](https://cloud.githubusercontent.com/assets/9755598/20729394/cc697066-b64f-11e6-96dc-8f5791489d28.png)

![screen shot 2016-11-29 at 4 20 23 pm](https://cloud.githubusercontent.com/assets/9755598/20729400/cf47cb70-b64f-11e6-809d-849f2f251c42.png)
