### PR TITLE
Style update for PsyArXiv again [PREP-265]

### DIFF
--- a/app/styles/brands/psyarxiv.scss
+++ b/app/styles/brands/psyarxiv.scss
@@ -14,6 +14,10 @@
 );
 
 .preprint-advisory {
-    background: #ff383f;
-    color: white;
+    background: #caebf2;
+    color: black;
+}
+
+#view-page .osf-box-lt .fa {
+    color: #ff383f;
 }


### PR DESCRIPTION
### Before:
![screen shot 2016-11-30 at 14 08 13](https://cloud.githubusercontent.com/assets/3374510/20770248/0ccc1cee-b713-11e6-859e-f626ff998cb4.png)
![screen shot 2016-11-30 at 15 31 56](https://cloud.githubusercontent.com/assets/3374510/20770249/0f1a82ec-b713-11e6-84b1-ff1829289982.png)

### After:
![screen shot 2016-11-30 at 15 32 33](https://cloud.githubusercontent.com/assets/3374510/20770254/14ed45ba-b713-11e6-8b20-86b681eb5738.png)
![screen shot 2016-11-30 at 15 32 13](https://cloud.githubusercontent.com/assets/3374510/20770261/18aa9a54-b713-11e6-9cbb-13dc01f713c5.png)

## Ticket
https://openscience.atlassian.net/browse/PREP-265