### PR TITLE
Add license-picker to the preprints add/edit. [PREP-235]

### DIFF
--- a/app/components/file-uploader.js
+++ b/app/components/file-uploader.js
@@ -101,6 +101,8 @@ export default Ember.Component.extend({
                 .then(node => {
                     this.set('node', node);
                     this.send('upload');
+                    this.set('newNode', true);
+                    this.set('applyLicense', true);
                 })
                 .catch(() => {
                     this.set('uploadInProgress', false);
@@ -119,6 +121,8 @@ export default Ember.Component.extend({
                     this.set('node', child);
                     this.set('basicsAbstract', this.get('node.description') || null);
                     this.send('upload');
+                    this.set('newNode', true);
+                    this.set('applyLicense', true);
                 })
                 .catch(() => {
                     this.set('uploadInProgress', false);

--- a/app/components/preprint-form-body.js
+++ b/app/components/preprint-form-body.js
@@ -6,7 +6,7 @@ export default CpPanelBodyComponent.extend({
         if (this.$('textarea').length) {
             // Make textarea fill vertical height
             this.$().height('auto');
-            this.$('textarea').outerHeight(this.$().height() - this.$('span').height());
+            this.$('textarea').outerHeight(this.$().height() - this.$('span').height() - this.$('.col-xs-12').height());
             this.$().height('');
         }
     },

--- a/app/controllers/content.js
+++ b/app/controllers/content.js
@@ -129,7 +129,7 @@ export default Ember.Controller.extend(Analytics, {
 
     actions: {
         toggleLicenseText() {
-            this.set('showLicenseText', !this.get('showLicenseText'));
+            this.toggleProperty('showLicenseText');
         },
         expandMFR() {
             // State of fullScreenMFR before the transition (what the user perceives as the action)

--- a/app/controllers/content.js
+++ b/app/controllers/content.js
@@ -121,8 +121,8 @@ export default Ember.Controller.extend(Analytics, {
     fullLicenseText: Ember.computed('model.license', function() {
         let text = this.get('model.license.text');
         if (text) {
-            text = text.replace(/({{year}})/g, this.get('model.licenseRecord')['year'] || '');
-            text = text.replace(/({{copyrightHolders}})/g, this.get('model.licenseRecord')['copyright_holders'] ? this.get('model.licenseRecord')['copyright_holders'].join(',') : false || '');
+            text = text.replace(/({{year}})/g, this.get('model.licenseRecord').year || '');
+            text = text.replace(/({{copyrightHolders}})/g, this.get('model.licenseRecord').copyright_holders ? this.get('model.licenseRecord').copyright_holders.join(',') : false || '');
         }
         return text;
     }),

--- a/app/controllers/content.js
+++ b/app/controllers/content.js
@@ -44,6 +44,7 @@ export default Ember.Controller.extend(Analytics, {
     theme: Ember.inject.service(),
     fullScreenMFR: false,
     expandedAuthors: true,
+    showLicenseText: false,
     isAdmin: Ember.computed('node', function() {
         // True if the current user has admin permissions for the node that contains the preprint
         return (this.get('node.currentUserPermissions') || []).includes(permissions.ADMIN);
@@ -117,7 +118,19 @@ export default Ember.Controller.extend(Analytics, {
         return `https://dx.doi.org/${this.get('model.doi')}`;
     }),
 
+    fullLicenseText: Ember.computed('model.license', function() {
+        let text = this.get('model.license.text');
+        if (text) {
+            text = text.replace(/({{year}})/g, this.get('model.licenseRecord')['year'] || '');
+            text = text.replace(/({{copyrightHolders}})/g, this.get('model.licenseRecord')['copyright_holders'] ? this.get('model.licenseRecord')['copyright_holders'].join(',') : false || '');
+        }
+        return text;
+    }),
+
     actions: {
+        toggleLicenseText() {
+            this.set('showLicenseText', !this.get('showLicenseText'));
+        },
         expandMFR() {
             // State of fullScreenMFR before the transition (what the user perceives as the action)
             const beforeState = this.toggleProperty('fullScreenMFR') ? 'Expand' : 'Contract';

--- a/app/controllers/submit.js
+++ b/app/controllers/submit.js
@@ -599,7 +599,7 @@ export default Ember.Controller.extend(BasicsValidations, NodeActionsMixin, Tagg
                     year: this.get('model.licenseRecord') ? this.get('model.licenseRecord').year : false || date.getUTCFullYear().toString(),
                     copyrightHolders: this.get('model.licenseRecord') ? this.get('model.licenseRecord').copyright_holders.join(', ') : false || ''
                 });
-            })
+            });
         },
         stripDOI() {
             // Replaces the inputted doi link with just the doi itself

--- a/app/controllers/submit.js
+++ b/app/controllers/submit.js
@@ -305,7 +305,7 @@ export default Ember.Controller.extend(BasicsValidations, NodeActionsMixin, Tagg
         if (this.get('model.licenseRecord') || this.get('model.license.content')) {
             changed = changed || (this.get('model.license.name') !== this.get('basicsLicense.licenseType.name'));
             changed = changed || (this.get('model.licenseRecord').year !== this.get('basicsLicense.year'));
-            changed = changed || (this.get('model.licenseRecord.copyright_holders.length') ? this.get('model.licenseRecord.copyright_holders').join(',') : this.get('basicsLicense.copyrightHolders') !== '');
+            changed = changed || ((this.get('model.licenseRecord.copyright_holders.length') ? this.get('model.licenseRecord.copyright_holders').join(',') : '') !== this.get('basicsLicense.copyrightHolders'));
         } else {
             changed = changed || ((this.get('availableLicenses').toArray().length ? this.get('availableLicenses').toArray()[0].get('name') : null) !== this.get('basicsLicense.licenseType.name'));
             let date = new Date();

--- a/app/controllers/submit.js
+++ b/app/controllers/submit.js
@@ -201,8 +201,9 @@ export default Ember.Controller.extend(BasicsValidations, NodeActionsMixin, Tagg
     uploadValid: Ember.computed.alias('nodeLocked'), // Once the node has been locked (happens in step one of upload section), users are free to navigate through form unrestricted
     abstractValid: Ember.computed.alias('validations.attrs.basicsAbstract.isValid'),
     doiValid: Ember.computed.alias('validations.attrs.basicsDOI.isValid'),
+    licenseValid: false,
     // Basics fields that are being validated are abstract and doi (title validated in upload section). If validation added for other fields, expand basicsValid definition.
-    basicsValid: Ember.computed.and('abstractValid', 'doiValid'),
+    basicsValid: Ember.computed.and('abstractValid', 'doiValid', 'licenseValid'),
     // Must have at least one contributor. Backend enforces admin and bibliographic rules. If this form section is ever invalid, something has gone horribly wrong.
     authorsValid: Ember.computed.bool('contributors.length'),
     // Must select at least one subject (looking at pending subjects)
@@ -373,8 +374,10 @@ export default Ember.Controller.extend(BasicsValidations, NodeActionsMixin, Tagg
     }),
 
     actions: {
-        editLicense(license) {
+        editLicense(license, validates) {
+            debugger;
             this.set('basicsLicense', license);
+            this.set('licenseValid', validates);
         },
         next(currentPanelName) {
             // Open next panel

--- a/app/controllers/submit.js
+++ b/app/controllers/submit.js
@@ -590,7 +590,7 @@ export default Ember.Controller.extend(BasicsValidations, NodeActionsMixin, Tagg
 
             if (this.get('abstractChanged')) node.set('description', this.get('basicsAbstract'));
             if (this.get('tagsChanged')) node.set('tags', this.get('basicsTags'));
-            debugger;
+
 
             node.save()
                 .then(() => {
@@ -598,12 +598,36 @@ export default Ember.Controller.extend(BasicsValidations, NodeActionsMixin, Tagg
                         model.set('doi', this.get('basicsDOI') || null);
                         model.save()
                             .then(() => {
-                                this.send('next', this.get('_names.2'));
+                                if (this.get('licenseChanged')) {
+                                    model.set('licenseRecord', {year: this.get('basicsLicense.year'), 'copyright_holders': this.get('basicsLicense.copyrightHolders')})
+                                    model.set('license', this.get('basicsLicense.license'));
+                                    model.save()
+                                        .then(() => {
+                                            this.send('next', this.get('_names.2'));
+                                        })
+                                        .catch(() => {
+                                            model.set('licenseRecord', currentLicenseRecord);
+                                            model.set('license', currentLicenseType);
+                                        })
+                                } else {
+                                    this.send('next', this.get('_names.2'));
+                                }
                             })
                             .catch(() => {
                                 model.set('doi', currentDOI);
                                 this.get('toast').error(this.get('i18n').t('submit.doi_error'));
                             });
+                    } else if (this.get('licenseChanged')) {
+                        model.set('licenseRecord', {year: this.get('basicsLicense.year'), 'copyright_holders': this.get('basicsLicense.copyrightHolders')})
+                        model.set('license', this.get('basicsLicense.license'));
+                        model.save()
+                            .then(() => {
+                                this.send('next', this.get('_names.2'));
+                            })
+                            .catch(() => {
+                                model.set('licenseRecord', currentLicenseRecord);
+                                model.set('license', currentLicenseType);
+                            })
                     } else {
                         this.send('next', this.get('_names.2'));
                     }

--- a/app/controllers/submit.js
+++ b/app/controllers/submit.js
@@ -291,14 +291,14 @@ export default Ember.Controller.extend(BasicsValidations, NodeActionsMixin, Tagg
             year: record ? record.year : null,
             copyrightHolders: record && record.copyright_holders ? record.copyright_holders.join(',') : null,
             licenseType: license || null
-        }
+        };
     }),
     licenseChanged: Ember.computed('model.license', 'model.licenseRecord', 'basicsLicense.year', 'basicsLicense.copyrightHolders', 'basicsLicense.licenseType', function() {
         let record = this.get('model.licenseRecord');
         let license = this.get('model.license') || null;
         let changed = false;
         if (record) {
-            changed = (record.year != this.get('basicsLicense.year')) || (this.get('basicsLicense.copyrightHolders') !== record.copyright_holders.join(','));
+            changed = (record.year !== this.get('basicsLicense.year')) || (this.get('basicsLicense.copyrightHolders') !== record.copyright_holders.join(','));
         } else {
             changed = (this.get('basicsLicense.year') !== null) || (this.get('basicsLicense.copyrightHolders') || []);
         }
@@ -506,10 +506,10 @@ export default Ember.Controller.extend(BasicsValidations, NodeActionsMixin, Tagg
                 if (license === null) {
                     this.set('applyLicense', true);
                 }
-                if (license.get('name').includes('No license')){
+                if (license.get('name').includes('No license')) {
                     this.set('applyLicense', true);
                 }
-            })
+            });
             const provider = this.get('store')
                 .peekRecord('preprint-provider', this.get('theme.id') || config.PREPRINTS.provider);
 
@@ -584,11 +584,11 @@ export default Ember.Controller.extend(BasicsValidations, NodeActionsMixin, Tagg
             this.set('basicsTags', this.get('node.tags').slice(0));
             this.set('basicsAbstract', this.get('node.description'));
             this.set('basicsDOI', this.get('model.doi'));
-            let date = new Date()
+            let date = new Date();
             this.set('basicsLicense', {
-                licenseType: this.get('model.license')|| this.get('availableLicenses').toArray()[0],
-                year: this.get('model.licenseRecord')['year'] || date.getUTCFullYear().toString(),
-                copyrightHolders: this.get('model.licenseRecord')['copyright_holders'].join(', ') || ''
+                licenseType: this.get('model.license') || this.get('availableLicenses').toArray()[0],
+                year: this.get('model.licenseRecord').year || date.getUTCFullYear().toString(),
+                copyrightHolders: this.get('model.licenseRecord').copyright_holders.join(', ') || ''
             });
         },
         stripDOI() {
@@ -608,15 +608,15 @@ export default Ember.Controller.extend(BasicsValidations, NodeActionsMixin, Tagg
             let currentLicenseRecord = model.get('licenseRecord');
             let currentNodeLicenseType = node.get('license');
             let currentNodeLicenseRecord = node.get('nodeLicense');
-            let newCopyrightHolders = ['']
+            let newCopyrightHolders = [''];
             if (this.get('basicsLicense.copyrightHolders') && this.get('basicsLicense.copyrightHolders').length) {
-                newCopyrightHolders = this.get('basicsLicense.copyrightHolders').split(',')
+                newCopyrightHolders = this.get('basicsLicense.copyrightHolders').split(',');
             }
 
             if (this.get('abstractChanged')) node.set('description', this.get('basicsAbstract'));
             if (this.get('tagsChanged')) node.set('tags', this.get('basicsTags'));
             if (this.get('licenseChanged') && this.get('applyLicense')) {
-                node.set('nodeLicense', {year: this.get('basicsLicense.year'), 'copyright_holders': newCopyrightHolders});
+                node.set('nodeLicense', {year: this.get('basicsLicense.year'), copyright_holders: newCopyrightHolders});
                 node.set('license', this.get('basicsLicense.licenseType'));
             }
 
@@ -625,7 +625,7 @@ export default Ember.Controller.extend(BasicsValidations, NodeActionsMixin, Tagg
                     if (this.get('doiChanged')) {
                         model.set('doi', this.get('basicsDOI') || null);
                         if (this.get('licenseChanged')) {
-                            model.set('licenseRecord', {year: this.get('basicsLicense.year'), 'copyright_holders': newCopyrightHolders});
+                            model.set('licenseRecord', {year: this.get('basicsLicense.year'), copyright_holders: newCopyrightHolders});
                             model.set('license', this.get('basicsLicense.licenseType'));
                         }
                         model.save()
@@ -639,7 +639,7 @@ export default Ember.Controller.extend(BasicsValidations, NodeActionsMixin, Tagg
                                 this.get('toast').error(this.get('i18n').t('submit.doi_error'));
                             });
                     } else if (this.get('licenseChanged')) {
-                        model.set('licenseRecord', {year: this.get('basicsLicense.year'), 'copyright_holders': newCopyrightHolders});
+                        model.set('licenseRecord', {year: this.get('basicsLicense.year'), copyright_holders: newCopyrightHolders});
                         model.set('license', this.get('basicsLicense.licenseType'));
                         model.save()
                             .then(() => {

--- a/app/controllers/submit.js
+++ b/app/controllers/submit.js
@@ -596,8 +596,8 @@ export default Ember.Controller.extend(BasicsValidations, NodeActionsMixin, Tagg
                     if (this.get('doiChanged')) {
                         model.set('doi', this.get('basicsDOI') || null);
                         if (this.get('licenseChanged')) {
-                            model.set('licenseRecord', {year: this.get('basicsLicense.year'), 'copyright_holders': this.get('basicsLicense.copyrightHolders')})
-                            model.set('license', this.get('basicsLicense.license'));
+                            model.set('licenseRecord', {year: this.get('basicsLicense.year'), 'copyright_holders': this.get('basicsLicense.copyrightHolders') ? this.get('basicsLicense.copyrightHolders').split(',') : []})
+                            model.set('license', this.get('basicsLicense.licenseType'));
                         }
                         model.save()
                             .then(() => {
@@ -610,8 +610,8 @@ export default Ember.Controller.extend(BasicsValidations, NodeActionsMixin, Tagg
                                 this.get('toast').error(this.get('i18n').t('submit.doi_error'));
                             });
                     } else if (this.get('licenseChanged')) {
-                        model.set('licenseRecord', {year: this.get('basicsLicense.year'), 'copyright_holders': this.get('basicsLicense.copyrightHolders')})
-                        model.set('license', this.get('basicsLicense.license'));
+                        model.set('licenseRecord', {year: this.get('basicsLicense.year'), 'copyright_holders': this.get('basicsLicense.copyrightHolders') ? this.get('basicsLicense.copyrightHolders').split(',') : []})
+                        model.set('license', this.get('basicsLicense.licenseType'));
                         model.save()
                             .then(() => {
                                 this.send('next', this.get('_names.2'));

--- a/app/controllers/submit.js
+++ b/app/controllers/submit.js
@@ -375,7 +375,6 @@ export default Ember.Controller.extend(BasicsValidations, NodeActionsMixin, Tagg
 
     actions: {
         editLicense(license, validates) {
-            debugger;
             this.set('basicsLicense', license);
             this.set('licenseValid', validates);
         },
@@ -596,24 +595,17 @@ export default Ember.Controller.extend(BasicsValidations, NodeActionsMixin, Tagg
                 .then(() => {
                     if (this.get('doiChanged')) {
                         model.set('doi', this.get('basicsDOI') || null);
+                        if (this.get('licenseChanged')) {
+                            model.set('licenseRecord', {year: this.get('basicsLicense.year'), 'copyright_holders': this.get('basicsLicense.copyrightHolders')})
+                            model.set('license', this.get('basicsLicense.license'));
+                        }
                         model.save()
                             .then(() => {
-                                if (this.get('licenseChanged')) {
-                                    model.set('licenseRecord', {year: this.get('basicsLicense.year'), 'copyright_holders': this.get('basicsLicense.copyrightHolders')})
-                                    model.set('license', this.get('basicsLicense.license'));
-                                    model.save()
-                                        .then(() => {
-                                            this.send('next', this.get('_names.2'));
-                                        })
-                                        .catch(() => {
-                                            model.set('licenseRecord', currentLicenseRecord);
-                                            model.set('license', currentLicenseType);
-                                        })
-                                } else {
-                                    this.send('next', this.get('_names.2'));
-                                }
+                                this.send('next', this.get('_names.2'));
                             })
                             .catch(() => {
+                                model.set('licenseRecord', currentLicenseRecord);
+                                model.set('license', currentLicenseType);
                                 model.set('doi', currentDOI);
                                 this.get('toast').error(this.get('i18n').t('submit.doi_error'));
                             });
@@ -627,7 +619,7 @@ export default Ember.Controller.extend(BasicsValidations, NodeActionsMixin, Tagg
                             .catch(() => {
                                 model.set('licenseRecord', currentLicenseRecord);
                                 model.set('license', currentLicenseType);
-                            })
+                            });
                     } else {
                         this.send('next', this.get('_names.2'));
                     }

--- a/app/locales/en/translations.js
+++ b/app/locales/en/translations.js
@@ -31,6 +31,7 @@ export default {
         convert_component: `The preprint will be organized in the current component`,
         copy_inside_project: `The preprint will be organized in a new component`,
         open_science_framework: `Open Science Framework`,
+        license: 'License',
     },
     application: {
         // Nothing to translate

--- a/app/locales/en/translations.js
+++ b/app/locales/en/translations.js
@@ -156,6 +156,10 @@ export default {
                 },
                 abstract: {
                     placeholder: `Add a brief summary of your preprint`
+                },
+                license: {
+                    apply_license_title: `Apply this license to my OSF Project.`,
+                    apply_license_text: `Selecting a license for your preprint does not automatically apply the license to your OSF project.`
                 }
             },
             authors: {

--- a/app/mixins/setup-submit-controller.js
+++ b/app/mixins/setup-submit-controller.js
@@ -5,6 +5,7 @@ import permissions from 'ember-osf/const/permissions';
 // The submit controller/template is used to handle both Add and Edit modes for a preprint.  Contains
 // the setupController items necessary for both Add and Edit Modes.
 export default Ember.Mixin.create({
+    theme: Ember.inject.service(),
     panelActions: Ember.inject.service('panelActions'),
 
     setupSubmitController(controller, model) {
@@ -21,7 +22,11 @@ export default Ember.Mixin.create({
                 controller.set('providers', providers);
             }
         );
-
+        this.get('theme.provider').then(provider => {
+            provider.query('licensesAcceptable', {'page[size]': 20}).then(licenses => {
+                controller.set('availableLicenses', licenses)
+            })
+        });
         this.get('currentUser').load()
             .then((user) => {
                 controller.set('user', user);

--- a/app/mixins/setup-submit-controller.js
+++ b/app/mixins/setup-submit-controller.js
@@ -24,8 +24,8 @@ export default Ember.Mixin.create({
         );
         this.get('theme.provider').then(provider => {
             provider.query('licensesAcceptable', {'page[size]': 20}).then(licenses => {
-                controller.set('availableLicenses', licenses)
-            })
+                controller.set('availableLicenses', licenses);
+            });
         });
         this.get('currentUser').load()
             .then((user) => {

--- a/app/templates/components/preprint-form-header.hbs
+++ b/app/templates/components/preprint-form-header.hbs
@@ -37,6 +37,7 @@
     <div class="m-t-md preprint-header-preview">
         {{#if (or isValidationActive editMode)}}
             {{#if (eq name 'Basics')}}
+                <p><em class="m-r-md"> {{t "global.license"}}: </em> {{if license license.name (t "global.none")}} </p>
                 <p><em class="m-r-md"> {{t "global.doi"}}: </em> {{if doi doi (t "global.none")}} </p>
                 <p>
                     <em class="m-r-md"> {{t "global.tags"}}: </em>

--- a/app/templates/components/preprint-form-project-select.hbs
+++ b/app/templates/components/preprint-form-project-select.hbs
@@ -134,6 +134,8 @@
                     abandonedPreprint=abandonedPreprint
                     resumeAbandonedPreprint=resumeAbandonedPreprint
                     basicsAbstract=basicsAbstract
+                    applyLicense=applyLicense
+                    newNode=newNode
                 }}
             {{/if}}
         {{else}}

--- a/app/templates/content.hbs
+++ b/app/templates/content.hbs
@@ -88,6 +88,11 @@
                     {{/if}}
 
                     <div class="p-t-xs">
+                        <h4 class="p-v-md f-w-md">{{t "global.license"}}</h4>
+                        <p class="p-v-md">{{model.license.name}}</p>
+                    </div>
+
+                    <div class="p-t-xs">
                         <h4 class="p-v-md f-w-md">{{t "content.disciplines"}}</h4>
                         {{#each disciplineReduced as |subject|}}
                             <span class='subject-preview'>{{subject.text}}</span>

--- a/app/templates/content.hbs
+++ b/app/templates/content.hbs
@@ -89,7 +89,19 @@
 
                     <div class="p-t-xs">
                         <h4 class="p-v-md f-w-md">{{t "global.license"}}</h4>
-                        <p class="p-v-md">{{model.license.name}}</p>
+                        <p class="p-v-md">
+                            {{model.license.name}}
+                            <span style='cursor: pointer'>
+                                {{#if showLicenseText }}
+                                    {{fa-icon 'caret-up' click=(action 'toggleLicenseText')}}
+                                {{else}}
+                                    {{fa-icon 'caret-down' click=(action 'toggleLicenseText')}}
+                                {{/if}}
+                            </span>
+                        </p>
+                        {{#if showLicenseText}}
+                            <pre class='license-text' style='border:none; width:100%; text-align:justify; max-height: 300px;'>{{fullLicenseText}}</pre>
+                        {{/if}}
                     </div>
 
                     <div class="p-t-xs">

--- a/app/templates/content.hbs
+++ b/app/templates/content.hbs
@@ -90,6 +90,7 @@
                     <div class="p-t-xs">
                         <h4 class="p-v-md f-w-md">{{t "global.license"}}</h4>
                         <p class="p-v-md p-b-sm">
+                            {{model.license.name}}
                             <span style='cursor: pointer'>
                                 {{#if showLicenseText }}
                                     {{fa-icon 'caret-down' click=(action 'toggleLicenseText')}}
@@ -97,7 +98,6 @@
                                     {{fa-icon 'caret-right' click=(action 'toggleLicenseText')}}
                                 {{/if}}
                             </span>
-                            {{model.license.name}}
                         </p>
                         {{#if showLicenseText}}
                             <pre class='license-text' style='font-size:75%; border:none; width:100%; text-align:justify; max-height: 300px;'>{{fullLicenseText}}</pre>

--- a/app/templates/content.hbs
+++ b/app/templates/content.hbs
@@ -89,18 +89,18 @@
 
                     <div class="p-t-xs">
                         <h4 class="p-v-md f-w-md">{{t "global.license"}}</h4>
-                        <p class="p-v-md">
-                            {{model.license.name}}
+                        <p class="p-v-md p-b-sm">
                             <span style='cursor: pointer'>
                                 {{#if showLicenseText }}
-                                    {{fa-icon 'caret-up' click=(action 'toggleLicenseText')}}
-                                {{else}}
                                     {{fa-icon 'caret-down' click=(action 'toggleLicenseText')}}
+                                {{else}}
+                                    {{fa-icon 'caret-right' click=(action 'toggleLicenseText')}}
                                 {{/if}}
                             </span>
+                            {{model.license.name}}
                         </p>
                         {{#if showLicenseText}}
-                            <pre class='license-text' style='border:none; width:100%; text-align:justify; max-height: 300px;'>{{fullLicenseText}}</pre>
+                            <pre class='license-text' style='font-size:75%; border:none; width:100%; text-align:justify; max-height: 300px;'>{{fullLicenseText}}</pre>
                         {{/if}}
                     </div>
 

--- a/app/templates/submit.hbs
+++ b/app/templates/submit.hbs
@@ -134,6 +134,9 @@
                         {{#preprint-form-section id='preprint-form-basics' class="preprint-form-block" name=name allowOpen=uploadValid errorAction=(action 'error') as |hasOpened|}}
                             {{preprint-form-header editMode=editMode doi=model.doi basicsSaveState=basicsSaveState tags=node.tags abstract=node.description name=name valid=(not basicsChanged) isValidationActive=hasOpened}}
                             {{#preprint-form-body}}
+                                <div class='row'>
+                                    {{license-picker licenses=availableLicenses currentValues=basicsLicense howCategories=false editLicense=(action 'editLicense') allowDismiss=false autosave=true}}
+                                </div>
                                 <div class="row">
                                     <div class="col-md-6">
                                         <div>

--- a/app/templates/submit.hbs
+++ b/app/templates/submit.hbs
@@ -173,8 +173,8 @@
                                         {{/unless}}
                                     </div>
                                     <div class="col-md-3 col-md-offset-6" class='input-group' style="margin: 20px">
-                                            <input onchange={{action 'applyLicenseToggle' true}} type="radio" checked={{applyLicense}}> Yes
-                                            <input onchange={{action 'applyLicenseToggle' false}} type="radio" checked={{eq applyLicense false}}> No
+                                        <input onchange={{action 'applyLicenseToggle' true}} type="radio" checked={{applyLicense}}> Yes
+                                        <input onchange={{action 'applyLicenseToggle' false}} type="radio" checked={{eq applyLicense false}}> No
                                     </div>
                                 </div>
                                 <div class="row">

--- a/app/templates/submit.hbs
+++ b/app/templates/submit.hbs
@@ -61,6 +61,8 @@
                                                 abandonedPreprint=abandonedPreprint
                                                 resumeAbandonedPreprint=(action 'resumeAbandonedPreprint')
                                                 basicsAbstract=basicsAbstract
+                                                newNode=newNode
+                                                applyLicense=applyLicense
                                             }}
                                         {{else if (eq currentState _State.EXISTING)}}
                                             {{preprint-form-project-select
@@ -102,6 +104,8 @@
                                               abandonedPreprint=abandonedPreprint
                                               resumeAbandonedPreprint=(action 'resumeAbandonedPreprint')
                                               basicsAbstract=basicsAbstract
+                                              newNode=newNode
+                                              applyLicense=applyLicense
                                               }}
                                         {{/if}}
                                     </div>
@@ -132,7 +136,7 @@
 
                     {{#with _names.[2] as |name|}}
                         {{#preprint-form-section id='preprint-form-basics' class="preprint-form-block" name=name allowOpen=uploadValid errorAction=(action 'error') as |hasOpened|}}
-                            {{preprint-form-header editMode=editMode doi=model.doi basicsSaveState=basicsSaveState tags=node.tags abstract=node.description name=name valid=(not basicsChanged) isValidationActive=hasOpened}}
+                            {{preprint-form-header editMode=editMode doi=model.doi basicsSaveState=basicsSaveState tags=node.tags abstract=node.description name=name valid=(not basicsChanged) license=model.license isValidationActive=hasOpened}}
                             {{#preprint-form-body}}
                                 <div class='row'>
                                     {{license-picker licenses=availableLicenses currentValues=basicsLicense howCategories=false editLicense=(action 'editLicense') allowDismiss=false autosave=true}}
@@ -156,6 +160,18 @@
                                             <span class="required">{{t "global.abstract"}}:</span>
                                         </label>
                                         {{validated-input model=this valuePath='basicsAbstract' placeholder=(t "submit.body.basics.abstract.placeholder") value=basicsAbstract large=true}}
+                                    </div>
+                                </div>
+                                <div class="row">
+                                    <div class="col-md-6">
+                                        <h4>{{if newNode 'Apply' 'Also apply'}} this license to my OSF Project.</h4>
+                                        {{#unless newNode}}
+                                            <p>Selecting a license for your preprint does not automatically apply the license to your OSF project.</p>
+                                        {{/unless}}
+                                    </div>
+                                    <div class="col-md-6" class='input-group pull-right' style="margin: 20px">
+                                            <input onchange={{action 'applyLicenseToggle' true}} type="radio" checked={{applyLicense}}> Yes
+                                            <input onchange={{action 'applyLicenseToggle' false}} type="radio" checked={{eq applyLicense false}}> No
                                     </div>
                                 </div>
                                 <div class="row">

--- a/app/templates/submit.hbs
+++ b/app/templates/submit.hbs
@@ -139,7 +139,10 @@
                             {{preprint-form-header editMode=editMode doi=model.doi basicsSaveState=basicsSaveState tags=node.tags abstract=node.description name=name valid=(not basicsChanged) license=model.license isValidationActive=hasOpened}}
                             {{#preprint-form-body}}
                                 <div class='row'>
-                                    {{license-picker licenses=availableLicenses currentValues=basicsLicense howCategories=false editLicense=(action 'editLicense') allowDismiss=false autosave=true}}
+                                    <div class='col-xs-12'>
+                                        {{license-picker licenses=availableLicenses currentValues=basicsLicense howCategories=false editLicense=(action 'editLicense') allowDismiss=false autosave=true showBorder=false}}
+                                        <br>
+                                    </div>
                                 </div>
                                 <div class="row">
                                     <div class="col-md-6">

--- a/app/templates/submit.hbs
+++ b/app/templates/submit.hbs
@@ -167,14 +167,14 @@
                                 </div>
                                 <div class="row">
                                     <div class="col-md-6">
-                                        <h4>{{if newNode 'Apply' 'Also apply'}} this license to my OSF Project.</h4>
-                                        {{#unless newNode}}
-                                            <p>Selecting a license for your preprint does not automatically apply the license to your OSF project.</p>
-                                        {{/unless}}
+                                        <h4>{{t "submit.body.basics.license.apply_license_title"}}</h4>
+                                        {{#if (or (not newNode) editMode)}}
+                                            <p>{{t "submit.body.basics.license.apply_license_text"}}</p>
+                                        {{/if}}
                                     </div>
                                     <div class="col-md-3 col-md-offset-6" class='input-group' style="margin: 20px">
                                         <input onchange={{action 'applyLicenseToggle' true}} type="radio" checked={{applyLicense}}> Yes
-                                        <input onchange={{action 'applyLicenseToggle' false}} type="radio" checked={{eq applyLicense false}}> No
+                                        <input onchange={{action 'applyLicenseToggle' false}} type="radio" checked={{not applyLicense}}> No
                                     </div>
                                 </div>
                                 <div class="row">

--- a/app/templates/submit.hbs
+++ b/app/templates/submit.hbs
@@ -169,7 +169,7 @@
                                             <p>Selecting a license for your preprint does not automatically apply the license to your OSF project.</p>
                                         {{/unless}}
                                     </div>
-                                    <div class="col-md-6" class='input-group pull-right' style="margin: 20px">
+                                    <div class="col-md-3 col-md-offset-6" class='input-group' style="margin: 20px">
                                             <input onchange={{action 'applyLicenseToggle' true}} type="radio" checked={{applyLicense}}> Yes
                                             <input onchange={{action 'applyLicenseToggle' false}} type="radio" checked={{eq applyLicense false}}> No
                                     </div>


### PR DESCRIPTION
## Purpose
Add the ability to display, modify and add licenses to a preprint, taking in the provider's default and subset of available licenses

## Changes
Addition of license widget on the edit/add preprint flows, and a show license field on the Preprint view page

## Depends on:
https://github.com/CenterForOpenScience/ember-osf/pull/152

## Tickets
https://openscience.atlassian.net/browse/PREP-235

## QA Consideration
For right now, the discard changes and save indicator are behaving weirdly. Fixing it ASAP