### PR TITLE
Change PsyArXiv social icons to watermelon in footer [PREP-267]

### DIFF
--- a/app/styles/brands/psyarxiv.scss
+++ b/app/styles/brands/psyarxiv.scss
@@ -18,6 +18,7 @@
     color: black;
 }
 
+.branded-footer .social a,
 #view-page .osf-box-lt .fa {
     color: #ff383f;
 }

--- a/app/styles/brands/psyarxiv.scss
+++ b/app/styles/brands/psyarxiv.scss
@@ -18,7 +18,7 @@
     color: black;
 }
 
-.branded-footer .social a,
+.branded-footer a,
 #view-page .osf-box-lt .fa {
     color: #ff383f;
 }


### PR DESCRIPTION
Only in the footer for PsyArXiv (content page icons have already been changed).

### Before:
![screen shot 2016-12-01 at 09 37 45](https://cloud.githubusercontent.com/assets/3374510/20799279/aebb68ce-b7af-11e6-97b1-841998dfe950.png)

### After:
![screen shot 2016-12-01 at 10 26 52](https://cloud.githubusercontent.com/assets/3374510/20799624/b747e020-b7b0-11e6-99d5-d2055938f33c.png)

## Ticket
https://openscience.atlassian.net/browse/PREP-267