### PR TITLE
[PREP-274] Move apply license to be next to license widget

### DIFF
--- a/app/templates/submit.hbs
+++ b/app/templates/submit.hbs
@@ -142,8 +142,21 @@
                                     <div class='col-xs-12'>
                                         {{license-picker licenses=availableLicenses currentValues=basicsLicense showCategories=false editLicense=(action 'editLicense') allowDismiss=false autosave=true showBorder=false}}
                                         <br>
+                                        <div class="row">
+                                            <div class='col-xs-12'>
+                                                <label> {{t "submit.body.basics.license.apply_license_title"}} </label>
+                                                {{#if (or (not newNode) editMode)}}
+                                                    <p>{{t "submit.body.basics.license.apply_license_text"}}</p>
+                                                {{/if}}
+                                                <span style="margin: 5px">
+                                                    <input onchange={{action 'applyLicenseToggle' true}} type="radio" checked={{applyLicense}}> Yes
+                                                    <input onchange={{action 'applyLicenseToggle' false}} type="radio" checked={{not applyLicense}}> No
+                                                </span>
+                                            </div>
+                                        </div>
                                     </div>
                                 </div>
+                                <br>
                                 <div class="row">
                                     <div class="col-md-6">
                                         <div>
@@ -163,18 +176,6 @@
                                             <span class="required">{{t "global.abstract"}}:</span>
                                         </label>
                                         {{validated-input model=this valuePath='basicsAbstract' placeholder=(t "submit.body.basics.abstract.placeholder") value=basicsAbstract large=true}}
-                                    </div>
-                                </div>
-                                <div class="row">
-                                    <div class="col-md-6">
-                                        <h4>{{t "submit.body.basics.license.apply_license_title"}}</h4>
-                                        {{#if (or (not newNode) editMode)}}
-                                            <p>{{t "submit.body.basics.license.apply_license_text"}}</p>
-                                        {{/if}}
-                                    </div>
-                                    <div class="col-md-3 col-md-offset-6" class='input-group' style="margin: 20px">
-                                        <input onchange={{action 'applyLicenseToggle' true}} type="radio" checked={{applyLicense}}> Yes
-                                        <input onchange={{action 'applyLicenseToggle' false}} type="radio" checked={{not applyLicense}}> No
                                     </div>
                                 </div>
                                 <div class="row">

--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "ember-link-action": "0.0.35",
     "ember-load-initializers": "^0.5.1",
     "ember-metrics": "0.6.3",
-    "ember-osf": "git+https://github.com/CenterForOpenScience/ember-osf.git#c69e10128f14edc82c35ebfe79f4a2a7b89d3ec2",
+    "ember-osf": "git+https://github.com/CenterForOpenScience/ember-osf.git#cd56714ae69f4828e21bf6f5a5d54be49b8ecde1",
     "ember-page-title": "3.0.6",
     "ember-power-select": "1.0.0-beta.7",
     "ember-read-more": "0.0.13",


### PR DESCRIPTION
## Purpose 
Make the form clearer by moving the apply license yes/no closer to the license widget

## Changes
### Before
![screen shot 2016-12-02 at 3 20 27 pm](https://cloud.githubusercontent.com/assets/6268982/20849493/f530740c-b8a4-11e6-9604-44f055d10769.png)

### After
![screen shot 2016-12-02 at 3 32 34 pm](https://cloud.githubusercontent.com/assets/6268982/20849508/029b60d4-b8a5-11e6-9fe7-87844c33e19b.png)
