### PR TITLE
[PREP-280] Use osf regex if not an outside provider

### DIFF
--- a/app/components/search-result.js
+++ b/app/components/search-result.js
@@ -29,29 +29,20 @@ export default Ember.Component.extend(Analytics, {
 
     osfID: Ember.computed('result', function() {
         let re = /osf.io\/(\w+)\/$/;
-        let re2 = /osf.io\/preprints\/(\w+)\/$/;
         // NOTE / TODO : This will have to be removed later. Currently the only "true" preprints are solely from the OSF
         // socarxiv and the like sometimes get picked up by as part of OSF, which is technically true. This will prevent
         // broken links to things that aren't really preprints.
-        if (this.get('result.providers.length') !== 1) {
-            return false;
-        }
-        if (this.get('result.providers').find(provider => provider.name === 'OSF')) {
+        if (this.get('result.providers.length') === 1 && this.get('result.providers').find(provider => provider.name === 'OSF'))
             for (let i = 0; i < this.get('result.identifiers.length'); i++)
                 if (re.test(this.get('result.identifiers')[i]))
                     return re.exec(this.get('result.identifiers')[i])[1];
-        } else {
-            for (let i = 0; i < this.get('result.identifiers.length'); i++)
-                if (re2.test(this.get('result.identifiers')[i]))
-                    return re2.exec(this.get('result.identifiers')[i])[1];
-        }
         return false;
     }),
 
     hyperlink: Ember.computed('result', function() {
         let re = null;
         for (let i = 0; i < this.get('result.providers.length'); i++)
-            re = this.providerUrlRegex[this.get('result.providers')[i].name] || this.providerUrlRegex['OSF'];
+            re = this.providerUrlRegex[this.get('result.providers')[i].name] || this.providerUrlRegex.OSF;
 
         const identifiers = this.get('result.identifiers').filter(ident => ident.startsWith('http://'));
 

--- a/app/components/search-result.js
+++ b/app/components/search-result.js
@@ -42,10 +42,9 @@ export default Ember.Component.extend(Analytics, {
     hyperlink: Ember.computed('result', function() {
         let re = null;
         for (let i = 0; i < this.get('result.providers.length'); i++)
-            re = this.providerUrlRegex[this.get('result.providers')[i].name] || null;
+            re = this.providerUrlRegex[this.get('result.providers')[i].name] || this.providerUrlRegex['OSF'];
 
         const identifiers = this.get('result.identifiers').filter(ident => ident.startsWith('http://'));
-        if (!re) return identifiers[0];
 
         for (let j = 0; j < identifiers.length; j++)
             if (re.test(identifiers[j]))

--- a/app/components/search-result.js
+++ b/app/components/search-result.js
@@ -29,13 +29,22 @@ export default Ember.Component.extend(Analytics, {
 
     osfID: Ember.computed('result', function() {
         let re = /osf.io\/(\w+)\/$/;
+        let re2 = /osf.io\/preprints\/(\w+)\/$/;
         // NOTE / TODO : This will have to be removed later. Currently the only "true" preprints are solely from the OSF
         // socarxiv and the like sometimes get picked up by as part of OSF, which is technically true. This will prevent
         // broken links to things that aren't really preprints.
-        if (this.get('result.providers.length') === 1 && this.get('result.providers').find(provider => provider.name === 'OSF'))
+        if (this.get('result.providers.length') !== 1) {
+            return false;
+        }
+        if (this.get('result.providers').find(provider => provider.name === 'OSF')) {
             for (let i = 0; i < this.get('result.identifiers.length'); i++)
                 if (re.test(this.get('result.identifiers')[i]))
                     return re.exec(this.get('result.identifiers')[i])[1];
+        } else {
+            for (let i = 0; i < this.get('result.identifiers.length'); i++)
+                if (re2.test(this.get('result.identifiers')[i]))
+                    return re2.exec(this.get('result.identifiers')[i])[1];
+        }
         return false;
     }),
 

--- a/app/components/search-result.js
+++ b/app/components/search-result.js
@@ -41,8 +41,13 @@ export default Ember.Component.extend(Analytics, {
 
     hyperlink: Ember.computed('result', function() {
         let re = null;
-        for (let i = 0; i < this.get('result.providers.length'); i++)
-            re = this.providerUrlRegex[this.get('result.providers')[i].name] || this.providerUrlRegex.OSF;
+        for (let i = 0; i < this.get('result.providers.length'); i++) {
+            //If the result has multiple providers, and one of them matches, use the first one found.
+            re = this.providerUrlRegex[this.get('result.providers')[i].name];
+            if (re) break;
+        }
+
+        re = re || this.providerUrlRegex.OSF;
 
         const identifiers = this.get('result.identifiers').filter(ident => ident.startsWith('http://'));
 


### PR DESCRIPTION
Problem
---------
On branded preprint search, clicking on the title of a preprint that's got an article DOI directs the user to the DOI. It should send the user to the branded view of the preprint. 
An example is on PsyArXiv - search for "go/no go association task"
This particular example is ALSO broken because the DOI seems invalid- that's unrelated.

Changes
--------

Link to ticket
--------------
https://openscience.atlassian.net/browse/PREP-280