### PR TITLE
Feature/Project Dropdown Filter both Projects and Components [PREP-254]

### DIFF
--- a/app/components/preprint-form-project-select.js
+++ b/app/components/preprint-form-project-select.js
@@ -55,4 +55,13 @@ export default Ember.Component.extend({
      * @property {boolean} fileSelect
      */
     fileSelect: false,
+
+    titleMatcher(node, term) {
+        // Passed into power-select component for customized searching.
+        const nodeTitle = (node.get('title') || '').toLowerCase();
+        const rootTitle = (node.get('root.title') || '').toLowerCase();
+        const parentTitle = (node.get('parent.title') || '').toLowerCase();
+        const lowerTerm = term.toLowerCase();
+        return nodeTitle.includes(lowerTerm) || rootTitle.includes(lowerTerm) || parentTitle.includes(lowerTerm) ? 1 : -1;
+    }
 });

--- a/app/components/preprint-form-project-select.js
+++ b/app/components/preprint-form-project-select.js
@@ -1,6 +1,7 @@
 import Ember from 'ember';
 import Permissions from 'ember-osf/const/permissions';
 import Analytics from '../mixins/analytics';
+import {stripDiacritics} from 'ember-power-select/utils/group-utils';
 
 /**
  * Preprint form project select widget - handles all ADD mode cases where the first step is to select an existing OSF project to contain
@@ -84,10 +85,26 @@ export default Ember.Component.extend(Analytics, {
 
     titleMatcher(node, term) {
         // Passed into power-select component for customized searching.
-        const nodeTitle = (node.get('title') || '').toLowerCase();
-        const rootTitle = (node.get('root.title') || '').toLowerCase();
-        const parentTitle = (node.get('parent.title') || '').toLowerCase();
-        const lowerTerm = term.toLowerCase();
-        return nodeTitle.includes(lowerTerm) || rootTitle.includes(lowerTerm) || parentTitle.includes(lowerTerm) ? 1 : -1;
+        // Returns results if match in node, root, or parent title
+        const fields = [
+            'title',
+            'root.title',
+            'parent.title'
+        ];
+
+        const sanitizedTerm = stripDiacritics(term).toLowerCase();
+
+        for (const field of fields) {
+            const fieldValue = node.get(field) || '';
+
+            if (!fieldValue) continue;
+
+            const sanitizedValue = stripDiacritics(fieldValue).toLowerCase();
+
+            if (sanitizedValue.includes(sanitizedTerm)) {
+                return 1;
+            }
+        }
+        return -1;
     }
 });

--- a/app/templates/components/preprint-form-project-select.hbs
+++ b/app/templates/components/preprint-form-project-select.hbs
@@ -18,7 +18,7 @@
                 {{else}}
                     {{#if userNodes}}
                         <div class="m-t-sm">
-                            {{#power-select options=userNodes placeholder="Click to select" searchField='title' selected=selectedNode onchange=(action "nodeSelected") as |node|}}
+                            {{#power-select options=userNodes placeholder="Click to select" matcher=titleMatcher selected=selectedNode onchange=(action "nodeSelected") as |node|}}
                                 {{get-ancestor-descriptor node}} <strong> {{node.title}}</strong>
                             {{/power-select}}
                         </div>


### PR DESCRIPTION
# Ticket 
https://openscience.atlassian.net/browse/PREP-254
❗️ Depends on https://github.com/CenterForOpenScience/ember-osf/pull/148

# Purpose

Searching for a project title to add a preprint to should also return all components under that project in the results.

# Changes

Pass a custom matcher into the power-select component that looks through the root title, node title, and parent title for a match, instead of just the node title.