### PR TITLE
Add redirect for urls with uppercase chars, remove duplicate metrics [PREP-286]

### DIFF
--- a/app/controllers/content.js
+++ b/app/controllers/content.js
@@ -153,12 +153,6 @@ export default Ember.Controller.extend(Analytics, {
         shareLink(href, network, action, label) {
             const metrics = Ember.get(this, 'metrics');
 
-            metrics.trackEvent({
-                category: network,
-                action,
-                label: window.location.href
-            });
-
             if (network.includes('email')) {
                 metrics.trackEvent({
                     category: 'link',

--- a/app/routes/provider.js
+++ b/app/routes/provider.js
@@ -16,7 +16,7 @@ export default Ember.Route.extend({
             if (slugLower !== slug) {
                 const {pathname} = window.location;
                 window.location.pathname = pathname.replace(
-                    new RexExp(`^/preprints/${slug}`),
+                    new RegExp(`^/preprints/${slug}`),
                     `/preprints/${slugLower}`
                 );
             }

--- a/app/routes/provider.js
+++ b/app/routes/provider.js
@@ -10,8 +10,17 @@ export default Ember.Route.extend({
 
     beforeModel(transition) {
         const {slug} = transition.params.provider;
+        const slugLower = (slug || '').toLowerCase();
 
-        if (this.get('providerIds').includes(slug)) {
+        if (this.get('providerIds').includes(slugLower)) {
+            if (slugLower !== slug) {
+                const {pathname} = window.location;
+                window.location.pathname = pathname.replace(
+                    new RexExp(`^/preprints/${slug}`),
+                    `/preprints/${slugLower}`
+                );
+            }
+
             this.set('theme.id', slug);
         } else {
             this.set('theme.id', config.PREPRINTS.defaultProvider);


### PR DESCRIPTION
## Purpose
Make provider names case insensitive (redirects to correct location if it is the correct provider name, but wrong case)

Also, get rid of duplicate trackEvent for sharing link buttons on the content page (Google Analytics).

## Ticket
https://openscience.atlassian.net/browse/PREP-286