### PR TITLE
Feature/User Message "Projects" instead of "Nodes" [PREP-270]

### DIFF
--- a/app/locales/en/translations.js
+++ b/app/locales/en/translations.js
@@ -299,7 +299,7 @@ export default {
         },
         'preprint-form-project-select': {
             existing_project_selector: `The list of projects appearing in the selector are projects and components for which you have admin access.  Registrations are not included here.`,
-            no_valid_existing_nodes: `You have no valid nodes that can be converted into a preprint.  Go back to upload a new preprint.`,
+            no_valid_existing_nodes: `You have no available projects that can be converted into a preprint.  Go back to upload a new preprint.`,
             upload_preprint: `Upload preprint`,
             select_existing_file: `Select existing file as preprint`,
             edit_preprint_title_project: `Edit preprint title (will also become the name of the project)`,


### PR DESCRIPTION
<!-- Before submit your Pull Request, make sure you picked
     the right branch:

     - For hotfixes, select "master" as the target branch
     - For new features, select "develop" as the target branch
     - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch -->

## Purpose

Reference "projects" instead of "nodes" when user has no valid nodes that can be converted into a preprint.

## Changes

![screen shot 2016-12-08 at 9 11 35 am](https://cloud.githubusercontent.com/assets/9755598/21013081/ae736eda-bd26-11e6-861f-bff602c0a41d.png)


## Side effects

None

<!--Any possible side effects? -->


## Ticket

https://openscience.atlassian.net/browse/PREP-270
