### PR TITLE
Feature/Private Preprint Should Redirect to Page Not Found[PREP-288]

### DIFF
--- a/app/routes/content.js
+++ b/app/routes/content.js
@@ -143,8 +143,11 @@ export default Ember.Route.extend(Analytics, ResetScrollMixin, SetupSubmitContro
     },
     actions: {
         error(error, transition) {
-            if (error && error.errors && Ember.isArray(error.errors) && error.errors[0].detail === 'The requested node is no longer available.') {
-                this.intermediateTransitionTo('resource-deleted'); // Node containing preprint has been deleted. 410 Gone.
+            const detail = error && error.errors && Ember.isArray(error.errors) && error.errors[0].detail ? error.errors[0].detail : null;
+            if (detail && detail === 'The requested node is no longer available.') {
+                this.intermediateTransitionTo('resource-deleted'); // Node containing preprint has been deleted. APIv2 returned 410 Gone.
+            } else if (detail && (detail === 'You do not have permission to perform this action.' || detail === 'Authentication credentials were not provided.')) {
+                this.intermediateTransitionTo('page-not-found'); // API v2 returned 401 or 403.
             } else {
                 const slug = transition.params[transition.targetName].preprint_id;
 


### PR DESCRIPTION
<!-- Before submit your Pull Request, make sure you picked
     the right branch:

     - For hotfixes, select "master" as the target branch
     - For new features, select "develop" as the target branch
     - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch -->

## Purpose

Currently if a user tries to navigate to a preprint that has been made private and the user is not authenticated/not authorized, the page will get stuck in an infinite loop.

## Changes

Uses the specific error detail messages returned by the APIv2 to determine if 401 or 403 because we can't access the raw json in Ember and do not see the status code (looking at an Ember Error that has some of the info from the API v2 error but not all).  If error message is `You do not have permission to perform this action.` or `Authentication credentials were not provided.` on the preprints content page, redirects both to Page Not Found.

Otherwise, runs through existing redirect logic (sometimes we want to redirect back to OSF side and show the Page Not Found there, for example.)

## Side effects

<!--Any possible side effects? -->


## Ticket

<!-- Link to JIRA ticket, if applicable e.g. https://openscience.atlassian.net/browse/PREP-1234 -->

https://openscience.atlassian.net/browse/PREP-288