### PR TITLE
Feature/Branded Preprint Header Padding [PREP-283]

### DIFF
--- a/app/styles/brands/_brand.scss
+++ b/app/styles/brands/_brand.scss
@@ -27,6 +27,7 @@ $logo-dir: '../img/provider_logos/';
         background-image: none;
         background-color: $theme-color-1;
         color: $theme-color-2;
+        padding-top: 100px;
 
         .preprint-brand {
             height: 140px;


### PR DESCRIPTION
<!-- Before submit your Pull Request, make sure you picked
     the right branch:

     - For hotfixes, select "master" as the target branch
     - For new features, select "develop" as the target branch
     - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch -->

## Purpose

OSF Preprints and Branded Preprint Headers share same top padding of 150px.  OSF preprints has two navbars, an OSF navbar and a preprints navbar, while branded has one navbar.  The padding on branded index pages seems large.

## Changes

Reduces top padding on branded preprint header by 50px, which is the height of the navbar.

Before
![screen shot 2016-12-08 at 11 51 51 am](https://cloud.githubusercontent.com/assets/9755598/21019178/8d22e4ce-bd3d-11e6-92d8-ca613eec84a1.png)

After
![screen shot 2016-12-08 at 11 51 41 am](https://cloud.githubusercontent.com/assets/9755598/21019182/8f12bff2-bd3d-11e6-8d50-e441787472a3.png)

<!-- Briefly describe or list your changes  -->

## Side effects

<!--Any possible side effects? -->


## Ticket

https://openscience.atlassian.net/browse/PREP-283