### PR TITLE
Feature/Engineering Tooltip Subdisciplines [PREP-275]

### DIFF
--- a/app/components/taxonomy-top-list.js
+++ b/app/components/taxonomy-top-list.js
@@ -9,7 +9,7 @@ export default Ember.Component.extend(Analytics, {
         'Arts and Humanities': 'Fine Arts, History, Music, Philosophy, Religion',
         'Business': 'Accounting, Finance and Financial Management, Human Resource Management, Marketing, Taxation',
         'Education': 'Curriculum and Instruction, Educational Administration and Supervision, Educational Leadership, Higher Education, Liberal Studies',
-        'Engineering': 'Aerospace Engineering, Automotive Engineering, Aviation, Biomedical Engineering and Bioengineering, Bioresource and Agricultural Engineering, Chemical Engineering, Civil and Environmental Engineering, Computational Engineering, Computer Engineering, Electrical and Computer Engineering, Engineering Education, Engineering Science and Materials, Materials Science and Engineering, Mechanical Engineering, Mining Engineering, Nanoscience and Nanotechnology, Nuclear Engineering, Operations Research, Systems Engineering and Industrial Engineering, Other Engineering, Risk Analysis',
+        'Engineering': 'Biomedical Engineering and Bioengineering, Chemical Engineering, Civil and Environmental Engineering, Electrical and Computer Engineering, Mechanical Engineering',
         'Law': 'Civil Law, Criminal Law, Legislation, State and Local Government Law, Supreme Court of the United States',
         'Life Sciences': 'Agriculture, Genetics and Genomics, Microbiology, Physiology, Zoology',
         'Medicine and Health Sciences': 'Anatomy, Diseases, Medical Sciences, Public Health, Veterinary Medicine',


### PR DESCRIPTION
## Purpose

Tooltip for engineering subdisciplines on preprints content page has too many subdisciplines.

## Changes

Changes subdisciplines for the tooltip to:
Biomedical Engineering and Bioengineering
Chemical Engineering
Civil and Environmental Engineering
Electrical and Computer Engineering
Mechanical Engineering

## Side effects

<!--Any possible side effects? -->


## Ticket

https://openscience.atlassian.net/browse/PREP-275