### PR TITLE
Fix/Citations Placement and Headings on Content Page [EOSF-393]

### DIFF
--- a/app/styles/app.scss
+++ b/app/styles/app.scss
@@ -1146,7 +1146,7 @@ label.title-label {
     white-space: nowrap;
 }
 .social-div {
-    margin-top: 10px;
+    margin-top: 5px;
 }
 
 

--- a/app/templates/content.hbs
+++ b/app/templates/content.hbs
@@ -80,35 +80,28 @@
                         </div>
                     {{/liquid-spacer}}
                     <div class="p-t-xs">
-                        <h4 class="p-v-md f-w-md">{{t "global.abstract"}}</h4>
+                        <h4 class="p-v-md f-w-md"><strong>{{t "global.abstract"}}</strong></h4>
                         <p class="abstract">{{node.description}}</p>
                     </div>
 
                     {{#if model.doi}}
                         <div class="p-t-xs">
-                            <h4 class="p-v-md  f-w-md">{{t "content.article_doi"}}</h4>
+                            <h4 class="p-v-md f-w-md"><strong>{{t "content.article_doi"}}</strong></h4>
                             <a href={{doiUrl}} {{action "click" "link" "Content - DOI" doiUrl}}>{{model.doi}}</a>
                         </div>
                     {{/if}}
 
-                    <div class="p-t-xs">
-                        <h4 class="p-v-md f-w-md">{{t "content.citations"}}</h4>
-                        {{citation-widget node=model}}
-                    </div>
-
                     {{#if model.license.name}}
                         <div class="p-t-xs">
-                            <h4 class="p-v-md f-w-md">{{t "global.license"}}</h4>
-                            <p class="p-v-md p-b-sm">
-                                {{model.license.name}}
-                                <span style='cursor: pointer'>
-                                    {{#if showLicenseText }}
-                                        {{fa-icon 'caret-down' click=(action 'toggleLicenseText')}}
-                                    {{else}}
-                                        {{fa-icon 'caret-right' click=(action 'toggleLicenseText')}}
-                                    {{/if}}
-                                </span>
-                            </p>
+                            <h4 class="p-v-md f-w-md"><strong>{{t "global.license"}}</strong></h4>
+                            {{model.license.name}}
+                            <span style='cursor: pointer'>
+                                {{#if showLicenseText }}
+                                    {{fa-icon 'caret-down' click=(action 'toggleLicenseText')}}
+                                {{else}}
+                                    {{fa-icon 'caret-right' click=(action 'toggleLicenseText')}}
+                                {{/if}}
+                            </span>
                             {{#if showLicenseText}}
                                 <pre style='white-space: pre-wrap; font-size:75%; border:none; width:100%; text-align:justify; max-height: 300px;'>{{fullLicenseText}}</pre>
                             {{/if}}
@@ -116,13 +109,13 @@
                     {{/if}}
 
                     <div class="p-t-xs">
-                        <h4 class="p-v-md f-w-md">{{t "content.disciplines"}}</h4>
+                        <h4 class="p-v-md f-w-md"><strong>{{t "content.disciplines"}}</strong></h4>
                         {{#each disciplineReduced as |subject|}}
                             <span class='subject-preview'>{{subject.text}}</span>
                         {{/each}}
                     </div>
-                    <div class="m-b-lg p-t-xs">
-                        <h4 class=" f-w-md p-v-md">{{t "global.tags"}}</h4>
+                    <div class="p-t-xs">
+                        <h4 class=" f-w-md p-v-md"><strong>{{t "global.tags"}}</strong></h4>
                         {{#if hasTag}}
                             {{#each node.tags as |tag|}}
                                 <span class="badge">{{tag}}</span>
@@ -131,6 +124,12 @@
                             {{t "global.none"}}
                         {{/if}}
                     </div>
+
+                    <div class="p-t-xs m-b-lg">
+                        <h4 class="p-v-md f-w-md"><strong>{{t "content.citations"}}</strong></h4>
+                        {{citation-widget node=model}}
+                    </div>
+
                     {{!PROJECT BUTTON}}
                     <div class="p-lg osf-box-lt row project-box">
                         <div class="col-xs-6 text-center">

--- a/app/templates/content.hbs
+++ b/app/templates/content.hbs
@@ -61,24 +61,22 @@
             </div> {{!END LEFT COL DIV}}
             {{#unless fullScreenMFR}}
                 <div class="col-md-5"> {{!RIGHT SIDE COL}}
-                    {{#liquid-spacer growDuration=250 growWidth=false}}
-                        <div class="share-row p-sm osf-box-lt clearfix">{{!SHARE ROW}}
-                            <div class="row" id="download_project clearfix">
-                                <div class="col-xs-12 col-lg-8">
-                                    <a class="btn btn-primary" href={{model.primaryFile.links.download}} onclick={{action 'click' 'link' 'Preprints - Content - Download'}}>{{t "content.share.download_preprint"}}</a>
-                                    <span class="p-sm">{{t "content.share.downloads"}}: {{model.primaryFile.extra.downloads}}</span>
-                                </div>
-                                <div class="col-xs-12 col-lg-4 social-div">
-                                    <span class="p-xs pull-right social-media-icons">
-                                        <a class="m-r-xs text-smaller" href={{twitterHref}} onclick={{action 'shareLink' twitterHref 'Twitter' 'Preprints - Content - tweet'}}>{{fa-icon 'twitter-square' size=2 }}</a>
-                                        <a class="m-r-xs text-smaller" href={{facebookHref}} onclick={{action 'shareLink' facebookHref 'Facebook' 'Preprints - Content - share'}}>{{fa-icon 'facebook-square' size=2 }}</a>
-                                        <a class="m-r-xs text-smaller" href={{linkedinHref}} onclick={{action 'shareLink' linkedinHref 'LinkedIn' 'Preprints - Content - share'}}>{{fa-icon 'linkedin-square' size=2 }}</a>
-                                        <a class="m-r-xs text-smaller" href={{emailHref}} onbeforeclick={{action 'shareLink' emailHref 'link' 'click' 'Preprints - Content - email'}}>{{fa-icon 'envelope' size=2 }}</a>
-                                    </span>
-                                </div>
+                    <div class="share-row p-sm osf-box-lt clearfix">{{!SHARE ROW}}
+                        <div class="row" id="download_project clearfix">
+                            <div class="col-xs-12 col-lg-8">
+                                <a class="btn btn-primary" href={{model.primaryFile.links.download}} onclick={{action 'click' 'link' 'Preprints - Content - Download'}}>{{t "content.share.download_preprint"}}</a>
+                                <span class="p-md">{{t "content.share.downloads"}}: {{model.primaryFile.extra.downloads}}</span>
+                            </div>
+                            <div class="col-xs-12 col-lg-4 social-div">
+                                <span class="pull-right social-media-icons">
+                                    <a class="m-r-xs text-smaller" href={{twitterHref}} onclick={{action 'shareLink' twitterHref 'Twitter' 'Preprints - Content - tweet'}}>{{fa-icon 'twitter-square' size=2 }}</a>
+                                    <a class="m-r-xs text-smaller" href={{facebookHref}} onclick={{action 'shareLink' facebookHref 'Facebook' 'Preprints - Content - share'}}>{{fa-icon 'facebook-square' size=2 }}</a>
+                                    <a class="m-r-xs text-smaller" href={{linkedinHref}} onclick={{action 'shareLink' linkedinHref 'LinkedIn' 'Preprints - Content - share'}}>{{fa-icon 'linkedin-square' size=2 }}</a>
+                                    <a class="m-r-xs text-smaller" href={{emailHref}} onbeforeclick={{action 'shareLink' emailHref 'link' 'click' 'Preprints - Content - email'}}>{{fa-icon 'envelope' size=2 }}</a>
+                                </span>
                             </div>
                         </div>
-                    {{/liquid-spacer}}
+                    </div>
                     <div class="p-t-xs">
                         <h4 class="p-v-md f-w-md"><strong>{{t "global.abstract"}}</strong></h4>
                         <p class="abstract">{{node.description}}</p>


### PR DESCRIPTION
## Ticket

https://openscience.atlassian.net/browse/EOSF-393

## Purpose

1 ) Move citations to last on the right side display; user entered metadata should come before the static citation content. 
2) Bold the headings to make more readable. 
3) Get rid of horizontal scroll bar (that appears when docking machine)..Removed liquid-spacer. This doesn't seem to be needed anymore.
![screen shot 2017-01-25 at 11 18 25 am](https://cloud.githubusercontent.com/assets/9755598/22298869/0fc45a48-e2f0-11e6-8437-1afd4545058a.png)



## Changes

<!-- Briefly describe or list your changes  -->

## Side effects

<!--Any possible side effects? -->



