### PR TITLE
Feature/Get-Ancestor-Descriptor Improvement [EOSF-395]

### DIFF
--- a/app/helpers/get-ancestor-descriptor.js
+++ b/app/helpers/get-ancestor-descriptor.js
@@ -44,6 +44,8 @@ export function getAncestorDescriptor(params/*, hash*/) {
         rootDescriptor = parentTitle + ' / ';
     } else if (rootId === parentParentId) { // Three levels
         rootDescriptor = rootTitle + ' / ' + parentTitle + ' / ';
+    } else if (parentParentId === undefined) { // Cannot deduce number of levels.
+        rootDescriptor = '... / ';
     } else { // Four + levels
         rootDescriptor = rootTitle + ' / ... / ' + parentTitle + ' / ';
     }


### PR DESCRIPTION
## Ticket

https://openscience.atlassian.net/browse/EOSF-395

## Purpose

Brought up by QA: It looks like if you are admin on a nested component (level 3), but not a contributor on the parent or component (levels 1 and 2), the project appears as "Private / ... / Private / 3" which implies there is another project between 1 and 2, even though there is not.

## Changes

If both the parent and root are private there is no way to deduce how many levels there are. I was giving it the default four levels since I didn't know, the dashboard gives it default three, but there's no way to tell. The API doesn't return a lot of info if items are private.

**If number of levels can't be deduced because of private projects in the hierarchy, change to this: `... / node title`**


## Side effects

<!--Any possible side effects? -->



