### PR TITLE
[EOSF-435] Add "see more" for long abstracts on view preprint page.

### DIFF
--- a/app/controllers/content.js
+++ b/app/controllers/content.js
@@ -129,12 +129,15 @@ export default Ember.Controller.extend(Analytics, {
     }),
 
     useShortenedDescription: Ember.computed('node.description', function() {
-        return this.get('node.description').length > 350;
+        return this.get('node.description') ? this.get('node.description').length > 350 : false;
     }),
 
-    shortenedDescription: Ember.computed('node.description', function() {
+    description: Ember.computed('node.description', 'expandedAbstract', function() {
         // Get a shortened version of the abstract, but doesnt cut in the middle of word by going
         // to the last space.
+        if (this.get('expandedAbstract')) {
+            return this.get('node.description');
+        }
         let text = this.get('node.description').slice(0, 350).split(' ');
         text.pop();
         return text.join(' ') + ' ...';

--- a/app/controllers/content.js
+++ b/app/controllers/content.js
@@ -45,6 +45,7 @@ export default Ember.Controller.extend(Analytics, {
     fullScreenMFR: false,
     expandedAuthors: true,
     showLicenseText: false,
+    expandedAbstract: false,
     isAdmin: Ember.computed('node', function() {
         // True if the current user has admin permissions for the node that contains the preprint
         return (this.get('node.currentUserPermissions') || []).includes(permissions.ADMIN);
@@ -127,6 +128,18 @@ export default Ember.Controller.extend(Analytics, {
         return text;
     }),
 
+    useShortenedDescription: Ember.computed('node.description', function() {
+        return this.get('node.description').length > 350;
+    }),
+
+    shortenedDescription: Ember.computed('node.description', function() {
+        // Get a shortened version of the abstract, but doesnt cut in the middle of word by going
+        // to the last space.
+        let text = this.get('node.description').slice(0, 350).split(' ');
+        text.pop();
+        return text.join(' ') + ' ...';
+    }),
+
     actions: {
         toggleLicenseText() {
             const licenseState = this.toggleProperty('showLicenseText') ? 'Expand' : 'Contract';
@@ -151,6 +164,9 @@ export default Ember.Controller.extend(Analytics, {
         // Unused
         expandAuthors() {
             this.toggleProperty('expandedAuthors');
+        },
+        expandAbstract() {
+            this.toggleProperty('expandedAbstract');
         },
         // Metrics are handled in the component
         chooseFile(fileItem) {

--- a/app/styles/app.scss
+++ b/app/styles/app.scss
@@ -329,6 +329,8 @@ ul.preprints-block-list {
     }
     .abstract {
         white-space: pre-line;
+        max-height: 300px;
+        overflow-y: scroll;
     }
     .project-box {
         div {

--- a/app/styles/app.scss
+++ b/app/styles/app.scss
@@ -329,8 +329,6 @@ ul.preprints-block-list {
     }
     .abstract {
         white-space: pre-line;
-        max-height: 300px;
-        overflow-y: scroll;
     }
     .project-box {
         div {

--- a/app/templates/content.hbs
+++ b/app/templates/content.hbs
@@ -79,7 +79,17 @@
                     </div>
                     <div class="p-t-xs">
                         <h4 class="p-v-md f-w-md"><strong>{{t "global.abstract"}}</strong></h4>
-                        <p class="abstract">{{node.description}}</p>
+                        {{#if useShortenedDescription}}
+                            {{#if expandedAbstract}}
+                                <p class="abstract">{{node.description}}</p>
+                                <a href='#' {{action 'expandAbstract'}}>See less</a>
+                            {{else}}
+                                <p class="abstract">{{shortenedDescription}}</p>
+                                <a href='#' {{action 'expandAbstract'}}>See more</a>
+                            {{/if}}
+                        {{else}}
+                            <p class="abstract">{{node.description}}</p>
+                        {{/if}}
                     </div>
 
                     {{#if model.doi}}

--- a/app/templates/content.hbs
+++ b/app/templates/content.hbs
@@ -80,13 +80,8 @@
                     <div class="p-t-xs">
                         <h4 class="p-v-md f-w-md"><strong>{{t "global.abstract"}}</strong></h4>
                         {{#if useShortenedDescription}}
-                            {{#if expandedAbstract}}
-                                <p class="abstract">{{node.description}}</p>
-                                <a href='#' {{action 'expandAbstract'}}>See less</a>
-                            {{else}}
-                                <p class="abstract">{{shortenedDescription}}</p>
-                                <a href='#' {{action 'expandAbstract'}}>See more</a>
-                            {{/if}}
+                            <p class="abstract">{{description}}</p>
+                            <button class='btn-link' {{action 'expandAbstract'}}>{{if expandedAbstract 'See less' 'See more'}}</button>
                         {{else}}
                             <p class="abstract">{{node.description}}</p>
                         {{/if}}


### PR DESCRIPTION
## Ticket

https://openscience.atlassian.net/browse/EOSF-435

## Purpose
Allow citations and other non-abstract pieces of the view preprint page to be seen right away.

## Changes
Add "see more" to the abstract that expands it if it is too long.

