### PR TITLE
[EOSF-238] Change scielo text to black and only have board container if it exists

### DIFF
--- a/app/styles/brands/scielo.scss
+++ b/app/styles/brands/scielo.scss
@@ -2,7 +2,7 @@
 
 @include brand(
     #FFFFFF,
-    white,
+    black,
     #6789D3,
     #3F6AC8,
     white,

--- a/app/templates/index.hbs
+++ b/app/templates/index.hbs
@@ -102,12 +102,18 @@
     {{/unless}}
 
     {{!ADVISORY GROUP}}
-    <div class="preprint-advisory p-v-md">
-        <div class="container">
-            <div class="row">
-                {{#if theme.isProvider}}
+    {{#if (and theme.isProvider theme.provider.advisoryBoard.length)}}
+        <div class="preprint-advisory p-v-md">
+            <div class="container">
+                <div class="row">
                     {{safe-markup theme.provider.advisoryBoard}}
-                {{else}}
+                </div>
+            </div>
+        </div>
+    {{else if (not theme.isProvider)}}
+        <div class="preprint-advisory p-v-md">
+            <div class="container">
+                <div class="row">
                     <div class="col-xs-12">
                         <h2>{{t "index.advisory.heading"}}</h2>
                         <p class="m-b-lg">{{t "index.advisory.paragraph"}}</p>
@@ -131,9 +137,9 @@
                             <li><b>Simine Vazire :</b> PsyArXiv, University of California, Davis</li>
                         </ul>
                     </div>
-                {{/if}}
+                </div>
             </div>
         </div>
-    </div>
+    {{/if}}
 
 </div> {{!END INDEX}}


### PR DESCRIPTION

## Ticket

https://openscience.atlassian.net/browse/EOSF-238

## Purpose & Changes
Fix bug on scielo, changing color to black to fix a lot of visibility issues, and only have the advisory container if the current provider actually has an advisory board.



