### PR TITLE
Feature/Preprint Provider Carousel [EOSF-499]

### DIFF
--- a/app/components/provider-carousel.js
+++ b/app/components/provider-carousel.js
@@ -20,23 +20,47 @@ import Analytics from '../mixins/analytics';
  * @class provider-carousel
  */
 export default Ember.Component.extend(Analytics, {
+    _resizeListener: null,
     providers: Ember.A(), // Pass in preprint providers
     itemsPerSlide: 5, // Default
     lightLogo: true, // Light logos by default, for Index page.
     numProviders: Ember.computed('providers', function() {
         return this.get('providers').length;
     }),
-    numSlides: Ember.computed('numProviders', function() {
+    numSlides: Ember.computed('numProviders', 'itemsPerSlide', function() {
         return Math.ceil(this.get('numProviders')/this.get('itemsPerSlide'));
     }),
-    slides: Ember.computed('numSlides', 'providers', function() {
+    slides: Ember.computed('numSlides', 'providers', 'itemsPerSlide', function() {
         const numSlides = this.get('numSlides');
         const itemsPerSlide = this.get('itemsPerSlide');
         return new Array(numSlides).fill().map((_, i) => {
             return this.get('providers').slice(i * itemsPerSlide, i * itemsPerSlide + itemsPerSlide);
         });
     }),
+    setSlideItems: function() {
+        // On xs screens, show one provider per slide. Otherwise, five.
+        if (window.innerWidth < 768) {
+            this.set('itemsPerSlide', 1);
+        } else {
+            this.set('itemsPerSlide', 5);
+        }
+    },
     didInsertElement: function () {
+        // On xs screen, display one provider per slide
         Ember.$('.carousel').carousel();
+    },
+    init: function() {
+        // Set resize listener so number of providers per slide can be changed
+        this._super(...arguments);
+        this.setSlideItems();
+        this._resizeListener = Ember.run.bind(this, this.setSlideItems);
+        Ember.$(window).on('resize', this._resizeListener);
+    },
+    willDestroy: function() {
+        // Unbinds _resizeListener
+        if (this._resizeListener) {
+            Ember.$(window).off('resize', this._resizeListener);
+        }
     }
 });
+

--- a/app/components/provider-carousel.js
+++ b/app/components/provider-carousel.js
@@ -1,0 +1,36 @@
+import Ember from 'ember';
+import Analytics from '../mixins/analytics';
+
+/**
+ * @module ember-preprints
+ * @submodule components
+ */
+
+/**
+ * Displays active preprint providers in a horizontal carousel with five providers per slide. Does not auto-advance.
+ *
+ * Sample usage:
+ * ```handlebars
+ * {{provider-carousel
+ *  providers=providers
+}}
+ * ```
+ * @class provider-carousel
+ */
+export default Ember.Component.extend(Analytics, {
+    providers: Ember.A(), // Pass in preprint providers
+    itemsPerSlide: 5, // Default
+    numProviders: Ember.computed('providers', function() {
+        return this.get('providers').length;
+    }),
+    numSlides: Ember.computed('numProviders', function() {
+        return Math.ceil(this.get('numProviders')/this.get('itemsPerSlide'));
+    }),
+    slides: Ember.computed('numSlides', 'providers', function() {
+        const numSlides = this.get('numSlides');
+        const itemsPerSlide = this.get('itemsPerSlide');
+        return new Array(numSlides).fill().map((_, i) => {
+            return this.get('providers').slice(i * itemsPerSlide, i * itemsPerSlide + itemsPerSlide);
+        });
+    })
+});

--- a/app/components/provider-carousel.js
+++ b/app/components/provider-carousel.js
@@ -8,6 +8,8 @@ import Analytics from '../mixins/analytics';
 
 /**
  * Displays active preprint providers in a horizontal carousel with five providers per slide. Does not auto-advance.
+ * Handles display on two pages: index (lightLogo=true) and discover (lightLogo=false).  If using elsewhere, need to add more customization
+ * around how provider logos and links are built.
  *
  * Sample usage:
  * ```handlebars
@@ -20,6 +22,7 @@ import Analytics from '../mixins/analytics';
 export default Ember.Component.extend(Analytics, {
     providers: Ember.A(), // Pass in preprint providers
     itemsPerSlide: 5, // Default
+    lightLogo: true, // Light logos by default, for Index page.
     numProviders: Ember.computed('providers', function() {
         return this.get('providers').length;
     }),

--- a/app/components/provider-carousel.js
+++ b/app/components/provider-carousel.js
@@ -14,8 +14,9 @@ import Analytics from '../mixins/analytics';
  * Sample usage:
  * ```handlebars
  * {{provider-carousel
- *  providers=providers
-}}
+ *      providers=providers
+ *      lightLogo=true
+ *}}
  * ```
  * @class provider-carousel
  */

--- a/app/components/provider-carousel.js
+++ b/app/components/provider-carousel.js
@@ -28,14 +28,12 @@ export default Ember.Component.extend(Analytics, {
         return this.get('providers').length;
     }),
     numSlides: Ember.computed('numProviders', 'itemsPerSlide', function() {
-        return Math.ceil(this.get('numProviders')/this.get('itemsPerSlide'));
+        return Math.ceil(this.get('numProviders') / this.get('itemsPerSlide'));
     }),
     slides: Ember.computed('numSlides', 'providers', 'itemsPerSlide', function() {
         const numSlides = this.get('numSlides');
         const itemsPerSlide = this.get('itemsPerSlide');
-        return new Array(numSlides).fill().map((_, i) => {
-            return this.get('providers').slice(i * itemsPerSlide, i * itemsPerSlide + itemsPerSlide);
-        });
+        return new Array(numSlides).fill().map((_, i) => this.get('providers').slice(i * itemsPerSlide, i * itemsPerSlide + itemsPerSlide));
     }),
     setSlideItems: function() {
         // On xs screens, show one provider per slide. Otherwise, five.

--- a/app/components/provider-carousel.js
+++ b/app/components/provider-carousel.js
@@ -32,5 +32,8 @@ export default Ember.Component.extend(Analytics, {
         return new Array(numSlides).fill().map((_, i) => {
             return this.get('providers').slice(i * itemsPerSlide, i * itemsPerSlide + itemsPerSlide);
         });
-    })
+    }),
+    didInsertElement: function () {
+        Ember.$('.carousel').carousel();
+    }
 });

--- a/app/styles/app.scss
+++ b/app/styles/app.scss
@@ -105,6 +105,13 @@ ul.comma-list {
 .carousel-control.left, .carousel-control.right {
     background-image: none // Overrides bootstrap defaults for carousel background gradient
 }
+.icon-next.dark-control {
+    color: black;
+}
+
+.icon-prev.dark-control {
+    color: black;
+}
 
 /* Main header with search bar */
 .preprint-header{

--- a/app/styles/app.scss
+++ b/app/styles/app.scss
@@ -102,6 +102,9 @@ ul.comma-list {
 /* INDEX page */
 /* Global to index */
 
+.carousel-control.left, .carousel-control.right {
+    background-image: none // Overrides bootstrap defaults for carousel background gradient
+}
 
 /* Main header with search bar */
 .preprint-header{

--- a/app/templates/components/provider-carousel.hbs
+++ b/app/templates/components/provider-carousel.hbs
@@ -4,23 +4,22 @@
         {{#each slides as |slide index|}}
             <div class={{if (not index) "item active" "item"}}>
                 {{#each slide as |provider index|}}
-                     <div class={{if (not index) "col-sm-2 col-sm-offset-1" "col-sm-2"}}>
-                         {{#if lightLogo}}
+                    <div class={{if (not index) "col-sm-2 col-sm-offset-1" "col-sm-2"}}>
+                        {{#if lightLogo}}
                             <a href="/preprints/{{provider.id}}"
                                 title={{provider.name}}
                                 onbeforeclick={{action 'click' 'link' (concat 'Index - Provider - ' provider.name)}}
-                            >
+                                >
                                 <div class="provider-logo provider-{{provider.id}}"></div>
                             </a>
-                         {{else}}
+                        {{else}}
                             <a href="/preprints/{{provider.id}}/discover"
                                 title={{provider.name}}
                                 onclick={{action 'click' 'link' (concat 'Preprints - Discover - Index ' provider.name)}}
                             >
                                 <div class="discover-provider-logo provider-{{provider.id}}-dark"></div>
                             </a>
-                         {{/if}}
-
+                        {{/if}}
                     </div>
                 {{/each}}
             </div>

--- a/app/templates/components/provider-carousel.hbs
+++ b/app/templates/components/provider-carousel.hbs
@@ -1,29 +1,39 @@
 {{!Provider Carousel}}
-
 <div id="providerCarousel" class="carousel slide" data-ride="carousel" data-interval="false">
     <div class="carousel-inner" role="listbox">
         {{#each slides as |slide index|}}
             <div class={{if (not index) "item active" "item"}}>
                 {{#each slide as |provider index|}}
                      <div class={{if (not index) "col-sm-2 col-sm-offset-1" "col-sm-2"}}>
-                        <a href="/preprints/{{provider.id}}"
-                           title={{provider.name}}
-                           onbeforeclick={{action 'click' 'link' (concat 'Index - Provider - ' provider.name)}}
-                        >
-                            <div class="provider-logo provider-{{provider.id}}"></div>
-                        </a>
+                         {{#if lightLogo}}
+                            <a href="/preprints/{{provider.id}}"
+                                title={{provider.name}}
+                                onbeforeclick={{action 'click' 'link' (concat 'Index - Provider - ' provider.name)}}
+                            >
+                                <div class="provider-logo provider-{{provider.id}}"></div>
+                            </a>
+                         {{else}}
+                            <a href="/preprints/{{provider.id}}/discover"
+                                title={{provider.name}}
+                                onclick={{action 'click' 'link' (concat 'Preprints - Discover - Index ' provider.name)}}
+                            >
+                                <div class="discover-provider-logo provider-{{provider.id}}-dark"></div>
+                            </a>
+                         {{/if}}
+
                     </div>
                 {{/each}}
             </div>
         {{/each}}
     </div>
     <a class="left carousel-control" href="#providerCarousel" role="button" data-slide="prev">
-        <span class="icon-prev fa fa-angle-left"></span>
+        <span class={{concat "icon-prev fa fa-angle-left" (if (not lightLogo) " dark-control")}}></span>
         <span class="sr-only">Previous</span>
     </a>
     <a class="right carousel-control" href="#providerCarousel" role="button" data-slide="next">
-        <span class="icon-next fa fa-angle-right"></span>
+        <span class={{concat "icon-next fa fa-angle-right" (if (not lightLogo) " dark-control")}}></span>
         <span class="sr-only">Next</span>
     </a>
 </div>
+
 

--- a/app/templates/components/provider-carousel.hbs
+++ b/app/templates/components/provider-carousel.hbs
@@ -1,0 +1,14 @@
+{{!Provider Carousel}}
+{{#each slides as |slide|}}
+    {{#each slide as |provider|}}
+        <div class="col-sm-4">
+            <a href="/preprints/{{provider.id}}"
+               title={{provider.name}}
+               onbeforeclick={{action 'click' 'link' (concat 'Index - Provider - ' provider.name)}}
+            >
+                <div class="provider-logo provider-{{provider.id}}"></div>
+            </a>
+        </div>
+    {{/each}}
+{{/each}}
+

--- a/app/templates/components/provider-carousel.hbs
+++ b/app/templates/components/provider-carousel.hbs
@@ -1,18 +1,6 @@
 {{!Provider Carousel}}
 
 <div id="providerCarousel" class="carousel slide" data-ride="carousel" data-interval="false">
-    <div class="col-sm-1">
-        <a class="carousel-control-prev" href="#providerCarousel" role="button" data-slide="prev">
-            <span> <i class="fa fa-angle-left"></i> </span>
-            <span class="sr-only">Previous</span>
-        </a>
-    </div>
-    <div class="col-sm-1 pull-right">
-        <a class="carousel-control-next" href="#providerCarousel" role="button" data-slide="next">
-            <span> <i class="fa fa-angle-right"></i> </span>
-            <span class="sr-only">Next</span>
-        </a>
-    </div>
     <div class="carousel-inner" role="listbox">
         {{#each slides as |slide index|}}
             <div class={{if (not index) "item active" "item"}}>
@@ -29,5 +17,13 @@
             </div>
         {{/each}}
     </div>
+    <a class="left carousel-control" href="#providerCarousel" role="button" data-slide="prev">
+        <span class="icon-prev fa fa-angle-left"></span>
+        <span class="sr-only">Previous</span>
+    </a>
+    <a class="right carousel-control" href="#providerCarousel" role="button" data-slide="next">
+        <span class="icon-next fa fa-angle-right"></span>
+        <span class="sr-only">Next</span>
+    </a>
 </div>
 

--- a/app/templates/components/provider-carousel.hbs
+++ b/app/templates/components/provider-carousel.hbs
@@ -1,14 +1,33 @@
 {{!Provider Carousel}}
-{{#each slides as |slide|}}
-    {{#each slide as |provider|}}
-        <div class="col-sm-4">
-            <a href="/preprints/{{provider.id}}"
-               title={{provider.name}}
-               onbeforeclick={{action 'click' 'link' (concat 'Index - Provider - ' provider.name)}}
-            >
-                <div class="provider-logo provider-{{provider.id}}"></div>
-            </a>
-        </div>
-    {{/each}}
-{{/each}}
+
+<div id="providerCarousel" class="carousel slide" data-ride="carousel" data-interval="false">
+    <div class="col-sm-1">
+        <a class="carousel-control-prev" href="#providerCarousel" role="button" data-slide="prev">
+            <span> <i class="fa fa-angle-left"></i> </span>
+            <span class="sr-only">Previous</span>
+        </a>
+    </div>
+    <div class="col-sm-1 pull-right">
+        <a class="carousel-control-next" href="#providerCarousel" role="button" data-slide="next">
+            <span> <i class="fa fa-angle-right"></i> </span>
+            <span class="sr-only">Next</span>
+        </a>
+    </div>
+    <div class="carousel-inner" role="listbox">
+        {{#each slides as |slide index|}}
+            <div class={{if (not index) "item active" "item"}}>
+                {{#each slide as |provider index|}}
+                     <div class={{if (not index) "col-sm-2 col-sm-offset-1" "col-sm-2"}}>
+                        <a href="/preprints/{{provider.id}}"
+                           title={{provider.name}}
+                           onbeforeclick={{action 'click' 'link' (concat 'Index - Provider - ' provider.name)}}
+                        >
+                            <div class="provider-logo provider-{{provider.id}}"></div>
+                        </a>
+                    </div>
+                {{/each}}
+            </div>
+        {{/each}}
+    </div>
+</div>
 

--- a/app/templates/discover.hbs
+++ b/app/templates/discover.hbs
@@ -26,18 +26,15 @@
             </div>
         </div>
         <div class="row m-v-md">
-            <div class="col-xs-8 col-xs-offset-2" style="text-align: center;">
+            <div class="col-xs-10 col-xs-offset-1" style="text-align: center;">
                 {{#if (not theme.isProvider)}}
                     <h3>{{t "discover.search.partner"}}</h3>
                     <div class="row">
-                        {{#each model as |provider|}}
-                            <a href="/preprints/{{provider.id}}/discover"
-                               title={{provider.name}}
-                               onclick={{action 'click' 'link' (concat 'Preprints - Discover - Index ' provider.name)}}
-                            >
-                                <div class="discover-provider-logo col-xs-4 provider-{{provider.id}}-dark"></div>
-                            </a>
-                        {{/each}}
+                        {{!CAROUSEL WITH PREPRINT PROVIDERS}}
+                        {{provider-carousel
+                            providers=model
+                            lightLogo=false
+                        }}
                     </div>
                 {{/if}}
             </div>

--- a/app/templates/index.hbs
+++ b/app/templates/index.hbs
@@ -66,7 +66,10 @@
                 </div>
             </div>
             <div class="row p-v-md">{{!BRANDED ROW}}
-                {{provider-carousel providers=model.brandedProviders}}  {{!CAROUSEL WITH PREPRINT PROVIDERS}}
+                {{!CAROUSEL WITH PREPRINT PROVIDERS}}
+                {{provider-carousel
+                    providers=model.brandedProviders
+                }}
             </div>
             <div class="row p-v-md">
                 <div class="col-md-12 text-center">

--- a/app/templates/index.hbs
+++ b/app/templates/index.hbs
@@ -66,16 +66,7 @@
                 </div>
             </div>
             <div class="row p-v-md">{{!BRANDED ROW}}
-                {{#each model.brandedProviders as |provider|}}
-                    <div class="col-sm-4">
-                        <a href="/preprints/{{provider.id}}"
-                           title={{provider.name}}
-                           onbeforeclick={{action 'click' 'link' (concat 'Index - Provider - ' provider.name)}}
-                        >
-                            <div class="provider-logo provider-{{provider.id}}"></div>
-                        </a>
-                    </div>
-                {{/each}}
+                {{provider-carousel providers=model.brandedProviders}}  {{!CAROUSEL WITH PREPRINT PROVIDERS}}
             </div>
             <div class="row p-v-md">
                 <div class="col-md-12 text-center">

--- a/tests/integration/components/provider-carousel-test.js
+++ b/tests/integration/components/provider-carousel-test.js
@@ -12,14 +12,5 @@ test('it renders', function(assert) {
 
   this.render(hbs`{{provider-carousel}}`);
 
-  assert.equal(this.$().text().trim(), '');
-
-  // Template block usage:
-  this.render(hbs`
-    {{#provider-carousel}}
-      template block text
-    {{/provider-carousel}}
-  `);
-
-  assert.equal(this.$().text().trim(), 'template block text');
+  assert.equal(this.$().context.innerText, 'PreviousNext');
 });

--- a/tests/integration/components/provider-carousel-test.js
+++ b/tests/integration/components/provider-carousel-test.js
@@ -1,0 +1,25 @@
+import { moduleForComponent, test } from 'ember-qunit';
+import hbs from 'htmlbars-inline-precompile';
+
+moduleForComponent('provider-carousel', 'Integration | Component | provider carousel', {
+  integration: true
+});
+
+test('it renders', function(assert) {
+
+  // Set any properties with this.set('myProperty', 'value');
+  // Handle any actions with this.on('myAction', function(val) { ... });
+
+  this.render(hbs`{{provider-carousel}}`);
+
+  assert.equal(this.$().text().trim(), '');
+
+  // Template block usage:
+  this.render(hbs`
+    {{#provider-carousel}}
+      template block text
+    {{/provider-carousel}}
+  `);
+
+  assert.equal(this.$().text().trim(), 'template block text');
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -2135,9 +2135,9 @@ ember-new-computed@^1.0.2:
   dependencies:
     ember-cli-babel "^5.1.5"
 
-"ember-osf@git+https://github.com/pattisdr/ember-osf.git#c4e87ff18b3f9125b87fbd3ce05e2c41eebdc3b6":
+"ember-osf@git+https://github.com/CenterForOpenScience/ember-osf.git#97a4f00dd86f360b561f3ee63b77297b3e6e0f1e":
   version "0.1.0"
-  resolved "git+https://github.com/pattisdr/ember-osf.git#c4e87ff18b3f9125b87fbd3ce05e2c41eebdc3b6"
+  resolved "git+https://github.com/CenterForOpenScience/ember-osf.git#97a4f00dd86f360b561f3ee63b77297b3e6e0f1e"
   dependencies:
     broccoli-funnel "^1.0.1"
     broccoli-merge-trees "^1.1.1"


### PR DESCRIPTION
<!-- Before submit your Pull Request, make sure you picked
     the right branch:

     - For hotfixes, select "master" as the target branch
     - For new features, select "develop" as the target branch
     - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch -->

## Ticket

https://openscience.atlassian.net/browse/EOSF-499

## Purpose

Add a scrolling list to the Preprint Services banner to allow the overflow of many preprint server logos to be easily and manually viewed by curious users.
We should show 5 logos and provide tooltips for what the logo is referencing.
This will replace the current logos.

## Changes
Added provider-carousel component to be used on both the Index and Discover Pages.   Properties are preprint-providers and lightLogo argument. If true, will display light logos and appropriate links for index page, if false, will display dark logos and links for discover page.  More customization of component would be needed if used elsewhere in the application.

Added listener for screen resize so the number of providers per slide on an xs screen is one.  >xs screen, num providers per slide is 5.

Sample usage:
```
 {{provider-carousel
       providers=providers
       lightLogo=true
 }}
```
### Index page:
![screen shot 2017-02-08 at 5 30 18 pm](https://cloud.githubusercontent.com/assets/9755598/22760432/6a7a76b8-ee24-11e6-96aa-88ec10fc1557.png)

![screen shot 2017-02-08 at 5 30 07 pm](https://cloud.githubusercontent.com/assets/9755598/22760435/6cc0bd88-ee24-11e6-81c1-87006b2f36d5.png)



### Discover page:
![screen shot 2017-02-08 at 5 29 36 pm](https://cloud.githubusercontent.com/assets/9755598/22760419/5ceee650-ee24-11e6-87ad-61afb14d2e3a.png)

![screen shot 2017-02-08 at 5 29 50 pm](https://cloud.githubusercontent.com/assets/9755598/22760428/6796163c-ee24-11e6-9415-dfda6af5629a.png)


## Side effects

<!--Any possible side effects? -->



