### PR TITLE
Using enter button to confirm the share action in modal [EOSF-478]

### DIFF
--- a/app/templates/components/confirm-share-preprint.hbs
+++ b/app/templates/components/confirm-share-preprint.hbs
@@ -9,7 +9,7 @@
     {{#bs-modal-footer}}
         <div align="right">
             <button {{action 'close'}} class="btn btn-default">{{t "global.cancel"}}</button>
-            <button class="btn btn-success" disabled={{shareButtonDisabled}} {{action savePreprint}}>{{t "global.share"}}</button>
+            <button class="btn btn-success"  autofocus disabled={{shareButtonDisabled}} {{action savePreprint}}>{{t "global.share"}}</button>
         </div>
     {{/bs-modal-footer}}
 {{/bs-modal}}


### PR DESCRIPTION
## Ticket
https://openscience.atlassian.net/browse/EOSF-478 

## Purpose
The preprint app has a modal to confirm sharing of new preprints. 
Pressing enter is needed to confirm share action presented in a modal.

## Changes
Used autofocus attribute, a boolean attribute, to specify that the button should automatically get focus when the modal loads.





