### PR TITLE
Hotfix/Provider Carousel <5 Providers [EOSF-505]

### DIFF
--- a/app/components/provider-carousel.js
+++ b/app/components/provider-carousel.js
@@ -36,6 +36,31 @@ export default Ember.Component.extend(Analytics, {
         const itemsPerSlide = this.get('itemsPerSlide');
         return new Array(numSlides).fill().map((_, i) => this.get('providers').slice(i * itemsPerSlide, i * itemsPerSlide + itemsPerSlide));
     }),
+    columnOffset: Ember.computed('numProviders', 'itemsPerSlide', function() {
+        // If only one slide of providers, center the provider logos by adding a column offset.
+        let offset = 'col-sm-offset-1';
+        const numProviders = this.get('numProviders');
+        if (numProviders <= this.get('itemsPerSlide')) {
+            switch (numProviders) {
+                case 1:
+                    offset = 'col-sm-offset-5';
+                    break;
+                case 2:
+                    offset = 'col-sm-offset-4';
+                    break;
+                case 3:
+                    offset = 'col-sm-offset-3';
+                    break;
+                case 4:
+                    offset = 'col-sm-offset-2';
+                    break;
+                case 5:
+                    offset = 'col-sm-offset-1';
+                    break;
+            }
+        }
+        return offset;
+    }),
     setSlideItems: function() {
         // On xs screens, show one provider per slide. Otherwise, five.
         if (window.innerWidth < 768) {
@@ -45,7 +70,6 @@ export default Ember.Component.extend(Analytics, {
         }
     },
     didInsertElement: function () {
-        // On xs screen, display one provider per slide
         Ember.$('.carousel').carousel();
     },
     init: function() {

--- a/app/templates/components/provider-carousel.hbs
+++ b/app/templates/components/provider-carousel.hbs
@@ -4,7 +4,7 @@
         {{#each slides as |slide index|}}
             <div class={{if (not index) "item active" "item"}}>
                 {{#each slide as |provider index|}}
-                    <div class={{if (not index) "col-sm-2 col-sm-offset-1" "col-sm-2"}}>
+                    <div class={{if (not index) (concat "col-sm-2 " columnOffset) "col-sm-2"}}>
                         {{#if lightLogo}}
                             <a href="/preprints/{{provider.id}}"
                                 title={{provider.name}}
@@ -25,14 +25,16 @@
             </div>
         {{/each}}
     </div>
-    <a class="left carousel-control" href="#providerCarousel" role="button" data-slide="prev">
-        <span class={{concat "icon-prev fa fa-angle-left" (if (not lightLogo) " dark-control")}}></span>
-        <span class="sr-only">Previous</span>
-    </a>
-    <a class="right carousel-control" href="#providerCarousel" role="button" data-slide="next">
-        <span class={{concat "icon-next fa fa-angle-right" (if (not lightLogo) " dark-control")}}></span>
-        <span class="sr-only">Next</span>
-    </a>
+    {{#if (gt numProviders itemsPerSlide)}}
+        <a class="left carousel-control" href="#providerCarousel" role="button" data-slide="prev">
+            <span class={{concat "icon-prev fa fa-angle-left" (if (not lightLogo) " dark-control")}}></span>
+            <span class="sr-only">Previous</span>
+        </a>
+        <a class="right carousel-control" href="#providerCarousel" role="button" data-slide="next">
+            <span class={{concat "icon-next fa fa-angle-right" (if (not lightLogo) " dark-control")}}></span>
+            <span class="sr-only">Next</span>
+        </a>
+    {{/if}}
 </div>
 
 

--- a/tests/integration/components/provider-carousel-test.js
+++ b/tests/integration/components/provider-carousel-test.js
@@ -9,8 +9,10 @@ test('it renders', function(assert) {
 
   // Set any properties with this.set('myProperty', 'value');
   // Handle any actions with this.on('myAction', function(val) { ... });
-
-  this.render(hbs`{{provider-carousel}}`);
+  this.set('providers', new Array(8));
+  this.render(hbs`{{provider-carousel
+      providers=providers
+  }}`);
 
   assert.equal(this.$().context.innerText, 'PreviousNext');
 });


### PR DESCRIPTION

## Ticket

https://openscience.atlassian.net/browse/EOSF-505

## Purpose
From ticket:
The logo carousel on the preprints landing page and discover page can display up to 5 logos before it needs carets to scroll to see more. The non-functional carets should be removed when there are fewer than 6 logos.
It would also be ideal if the logos could be centered, perhaps just making the number of columns equal to the number of items if it's less than five. Just make sure they don't get too tall or anything crazy.

## Changes

If five or less providers:
- Remove carets
- Center logos (by adding a dynamic column offset)

![screen shot 2017-02-09 at 5 17 35 pm](https://cloud.githubusercontent.com/assets/9755598/22805473/bb0589ca-eeeb-11e6-9a6c-be983b987803.png)

