### PR TITLE
[EOSF-285] Styling for Selected Sub-disciplines List

### DIFF
--- a/app/components/subject-picker/template.hbs
+++ b/app/components/subject-picker/template.hbs
@@ -2,7 +2,7 @@
     {{#each selected as |subject|}}
         <span class="subject">
             {{#each subject as |segment|}}
-                <div class="subject-container"><b class="subject-container-text">{{segment.text}} <button class="cancel-subject" aria-label="Remove subject" title="Remove" {{action 'deselect' subject}}><i class="fa fa-close"></i></button></b></div>
+                <div class="subject-container"><span class="subject-container-text">{{segment.text}}<button class="cancel-subject fa fa-close" aria-label="{{t 'submit.body.remove_subject_aria'}}" title="Remove" {{action 'deselect' subject}} /></span></div><span class="right-arrow"></span>
             {{/each}}
         </span>
     {{/each}}

--- a/app/components/subject-picker/template.hbs
+++ b/app/components/subject-picker/template.hbs
@@ -2,7 +2,7 @@
     {{#each selected as |subject|}}
         <span class="subject">
             {{#each subject as |segment|}}
-                <b>{{segment.text}}</b>
+                <div class="subject-container"><b>{{segment.text}}</b></div>
             {{/each}}
             {{fa-icon 'times' click=(action 'deselect' subject)}}
         </span>

--- a/app/components/subject-picker/template.hbs
+++ b/app/components/subject-picker/template.hbs
@@ -2,9 +2,8 @@
     {{#each selected as |subject|}}
         <span class="subject">
             {{#each subject as |segment|}}
-                <div class="subject-container"><b>{{segment.text}}</b></div>
+                <div class="subject-container"><b>{{segment.text}} <span class="cancel-subject" {{action 'deselect' subject}}></span></b></div>
             {{/each}}
-            {{fa-icon 'times' click=(action 'deselect' subject)}}
         </span>
     {{/each}}
 </div>

--- a/app/components/subject-picker/template.hbs
+++ b/app/components/subject-picker/template.hbs
@@ -2,7 +2,7 @@
     {{#each selected as |subject|}}
         <span class="subject">
             {{#each subject as |segment|}}
-                <div class="subject-container"><b>{{segment.text}} <span class="cancel-subject" {{action 'deselect' subject}}></span></b></div>
+                <div class="subject-container"><b class="subject-container-text">{{segment.text}} <button class="cancel-subject" aria-label="Remove subject" title="Remove" {{action 'deselect' subject}}><i class="fa fa-close"></i></button></b></div>
             {{/each}}
         </span>
     {{/each}}

--- a/app/locales/en/translations.js
+++ b/app/locales/en/translations.js
@@ -153,6 +153,7 @@ export default {
             file: `Preprint file`,
             title: `Preprint title`,
             subjects_description: `Select a discipline and subdiscipline, if relevant. Add more by clicking on a new discipline or subdiscipline.`,
+            remove_subject_aria: `Remove subject`,
             basics: {
                 doi: {
                     label: `If published, DOI of associated journal article (optional)`

--- a/app/styles/app.scss
+++ b/app/styles/app.scss
@@ -739,8 +739,10 @@ hr {
         color: white;
         overflow: hidden;
         padding: 0 2rem;
-        margin-right: 2rem;
-        margin-bottom: 1rem;
+        margin: {
+            right: 2rem;
+            bottom: 1rem;
+        }
         &:hover {
             & > .subject-container, & > .fa {
                 background-color: lighten($brand-primary, 10%);
@@ -789,20 +791,23 @@ hr {
                 & > b::before, & > b::after {
                     display: none;
                 }
-            }
-        }
-        & > .fa {
-            background-color: $brand-primary;
-            transition: background-color 0.1s linear;
-            color: white;
-            cursor: pointer;
-            margin-left: -5px;
-            padding: 8px 15px 7px;
-            &:hover {
-                color: lighten(red, 40%);
-            }
-            &:active {
-                color: lighten(red, 20%);
+                & > b > .cancel-subject {
+                    &:before {
+                        font: {
+                            family: FontAwesome;
+                            size: 11px;
+                        }
+                        cursor: pointer;
+                        content: "\f00d";
+                        padding-left: 5px;
+                    }
+                    &:hover {
+                        color: lighten(red, 40%);
+                    }
+                    &:active {
+                        color: lighten(red, 20%);
+                    }
+                }
             }
         }
     }

--- a/app/styles/app.scss
+++ b/app/styles/app.scss
@@ -733,78 +733,77 @@ hr {
     }
 }
 
-#preprint-form-subjects {
-    .subject {
-        display: inline-block;
-        color: white;
-        overflow: hidden;
-        padding: 0 2rem;
-        margin-bottom: 1rem;
-        &:hover {
-            .subject-container {
-                background-color: lighten($brand-primary, 10%);
-                .subject-container-text:after {
-                    border-left-color: lighten($brand-primary, 10%);
-                }
-            }
-        }
+.right-arrow {
+    border-top: 14px solid transparent;
+    border-bottom: 15px solid transparent;
+    border-left: 15px solid white;
+    position: absolute;
+    display: inline;
+    &:before {
+        content: '';
+        border-top: 14px solid transparent;
+        border-bottom: 15px solid transparent;
+        border-left: 15px solid $brand-primary;
+        position: absolute;
+        margin-left: -16px;
+        margin-top: -14px;
+        transition: border-color 0.1s linear;
+    }
+}
+
+.subject {
+    display: inline-block;
+    color: white;
+    overflow: hidden;
+    padding: 0 .5rem;
+    margin-bottom: 1rem;
+    font-weight: bold;
+    &:hover {
         .subject-container {
-            background-color: $brand-primary;
-            display: inline-block;
-            transition: background-color 0.1s linear;
-            margin-left: -10px;
-            padding-left: 10px;
-            .subject-container-text {
-                display: inline-block;
-                padding: 5px 15px ;
-                position: relative;
-                .cancel-subject {
-                    background: none;
-                    border: none;
-                    padding: 0;
-                    visibility: hidden;
-                    margin-left: -10px;
-                    &:hover {
-                        color: lighten(red, 40%);
-                    }
-                    &:active {
-                        color: lighten(red, 20%);
-                    }
-                }
-                &%pseudo {
-                    content: '';
-                    position: absolute;
-                    left: 100%;
-                    top: 0;
-                    border: {
-                        style: solid;
-                        width: 15px 0 15px 12px;
-                        color: transparent transparent transparent $brand-primary;
-                    }
-                }
-                &:before {
-                    @extend %pseudo;
-                    margin-left: 1px;
-                    border-left-color: white;
-                    z-index: 1;
-                }
-                &:after {
-                    @extend %pseudo;
-                    transition: border-color 0.1s linear;
-                    z-index: 2;
-                }
-            }
-            &:last-of-type {
-                .subject-container-text > .cancel-subject {
-                    visibility: visible;
-                    margin-left: 5px;
-                }
-                .subject-container-text:before, .subject-container-text:after {
-                    display: none;
-                }
-            }
+            background-color: lighten($brand-primary, 10%);
+        }
+        .right-arrow:before {
+            border-left-color: lighten($brand-primary, 10%);
         }
     }
+    .right-arrow:last-of-type {
+        display: none;
+    }
+}
+
+.subject-container {
+    background-color: $brand-primary;
+    display: inline-block;
+    transition: background-color 0.1s linear;
+    margin-left: -10px;
+    padding-left: 10px;
+    &:last-of-type {
+        .cancel-subject {
+            visibility: visible;
+            margin-left: 10px;
+        }
+    }
+}
+
+.subject-container-text {
+    display: inline-block;
+    padding: 5px 15px ;
+}
+
+.cancel-subject {
+    background: none;
+    border: none;
+    padding: 0;
+    visibility: hidden;
+    &:hover {
+        color: lighten(red, 40%);
+    }
+    &:active {
+        color: lighten(red, 20%);
+    }
+}
+
+#preprint-form-subjects {
     ul {
         height: 30rem;
         list-style: none;

--- a/app/styles/app.scss
+++ b/app/styles/app.scss
@@ -735,69 +735,69 @@ hr {
 
 #preprint-form-subjects {
     .subject {
-        background-color: $brand-primary;
         display: inline-block;
         color: white;
         overflow: hidden;
         padding: 0 2rem;
         margin-right: 2rem;
         margin-bottom: 1rem;
-        border-radius: 2px;
-        transition: background-color 0.1s linear;
         &:hover {
-            background-color: lighten($brand-primary, 10%);
-            & > b:after {
+            & > .subject-container, & > .fa {
+                background-color: lighten($brand-primary, 10%);
+            }
+            & > .subject-container > b:after {
                 border-left-color: lighten($brand-primary, 10%);
             }
         }
-        & > b {
+        .subject-container {
+            background-color: $brand-primary;
             display: inline-block;
-            padding: 5px 12px ;
-            position: relative;
-            border-radius: 4px;
-            &%pseudo {
-                content: '';
-                display: block;
-                position: absolute;
-                width: 0;
-                height: 0;
-                left: 100%;
-                top: 50%;
-                margin-top: -5rem;
-                border: {
-                    style: solid;
-                    width: 5rem 0 5rem 3rem;
-                    color: transparent transparent transparent $brand-primary;
+            transition: background-color 0.1s linear;
+            margin-left: -10px;
+            padding-left: 10px;
+            & > b {
+                display: inline-block;
+                padding: 5px 15px ;
+                position: relative;
+                border-radius: 4px;
+                &%pseudo {
+                    content: '';
+                    position: absolute;
+                    width: 0;
+                    height: 0;
+                    left: 100%;
+                    top: 0;
+                    border: {
+                        style: solid;
+                        width: 15px 0 15px 12px;
+                        color: transparent transparent transparent $brand-primary;
+                    }
+                }
+                &:before {
+                    @extend %pseudo;
+                    margin-left: 1px;
+                    border-left-color: white;
+                    z-index: 1;
+                }
+                &:after {
+                    @extend %pseudo;
+                    transition: border-color 0.1s linear;
+                    z-index: 2;
                 }
             }
-            &:before {
-                @extend %pseudo;
-                margin-left: 1px;
-                border-left-color: white;
-                z-index: 1;
-            }
-            &:after {
-                @extend %pseudo;
-                transition: border-color 0.1s linear;
-                z-index: 2;
-            }
-            &:first-child {
-                padding-left: 0;
-            }
             &:last-of-type {
-                padding-right: 2rem;
-                &:before, &:after {
+                & > b::before, & > b::after {
                     display: none;
                 }
             }
-            & + b {
-                margin-left: 2rem;
-            }
         }
         & > .fa {
+            background-color: $brand-primary;
+            transition: background-color 0.1s linear;
             color: white;
             cursor: pointer;
-            transition: color 0.1s linear;
+            margin-left: -5px;
+            padding: 8px 15px 7px;
             &:hover {
                 color: lighten(red, 40%);
             }

--- a/app/styles/app.scss
+++ b/app/styles/app.scss
@@ -739,16 +739,13 @@ hr {
         color: white;
         overflow: hidden;
         padding: 0 2rem;
-        margin: {
-            right: 2rem;
-            bottom: 1rem;
-        }
+        margin-bottom: 1rem;
         &:hover {
-            & > .subject-container, & > .fa {
+            .subject-container {
                 background-color: lighten($brand-primary, 10%);
-            }
-            & > .subject-container > b:after {
-                border-left-color: lighten($brand-primary, 10%);
+                .subject-container-text:after {
+                    border-left-color: lighten($brand-primary, 10%);
+                }
             }
         }
         .subject-container {
@@ -757,16 +754,26 @@ hr {
             transition: background-color 0.1s linear;
             margin-left: -10px;
             padding-left: 10px;
-            & > b {
+            .subject-container-text {
                 display: inline-block;
                 padding: 5px 15px ;
                 position: relative;
-                border-radius: 4px;
+                .cancel-subject {
+                    background: none;
+                    border: none;
+                    padding: 0;
+                    visibility: hidden;
+                    margin-left: -10px;
+                    &:hover {
+                        color: lighten(red, 40%);
+                    }
+                    &:active {
+                        color: lighten(red, 20%);
+                    }
+                }
                 &%pseudo {
                     content: '';
                     position: absolute;
-                    width: 0;
-                    height: 0;
                     left: 100%;
                     top: 0;
                     border: {
@@ -788,25 +795,12 @@ hr {
                 }
             }
             &:last-of-type {
-                & > b::before, & > b::after {
-                    display: none;
+                .subject-container-text > .cancel-subject {
+                    visibility: visible;
+                    margin-left: 5px;
                 }
-                & > b > .cancel-subject {
-                    &:before {
-                        font: {
-                            family: FontAwesome;
-                            size: 11px;
-                        }
-                        cursor: pointer;
-                        content: "\f00d";
-                        padding-left: 5px;
-                    }
-                    &:hover {
-                        color: lighten(red, 40%);
-                    }
-                    &:active {
-                        color: lighten(red, 20%);
-                    }
+                .subject-container-text:before, .subject-container-text:after {
+                    display: none;
                 }
             }
         }

--- a/app/styles/app.scss
+++ b/app/styles/app.scss
@@ -734,19 +734,19 @@ hr {
 }
 
 .right-arrow {
-    border-top: 14px solid transparent;
-    border-bottom: 15px solid transparent;
-    border-left: 15px solid white;
+    border-top: 1.5rem solid transparent;
+    border-bottom: 1.4rem solid transparent;
+    border-left: 1.5rem solid white;
     position: absolute;
     display: inline;
     &:before {
         content: '';
-        border-top: 14px solid transparent;
-        border-bottom: 15px solid transparent;
-        border-left: 15px solid $brand-primary;
+        border-top: 1.4rem solid transparent;
+        border-bottom: 1.3rem solid transparent;
+        border-left: 1.4rem solid $brand-primary;
         position: absolute;
-        margin-left: -16px;
-        margin-top: -14px;
+        margin-left: -1.5rem;
+        margin-top: -1.4rem;
         transition: border-color 0.1s linear;
     }
 }


### PR DESCRIPTION
<!-- Before submit your Pull Request, make sure you picked
     the right branch:

     - For hotfixes, select "master" as the target branch
     - For new features, select "develop" as the target branch
     - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch -->

## Ticket

- https://openscience.atlassian.net/browse/EOSF-285

## Purpose

When creating a preprint, disciplines and sub-disciplines would smash together when the screen became too small to fit on one line.  This will fix the styling of the disciplines and sub-disciplines when they break onto new lines.

## Changes

- Changed HTML to add another container around each listed item and changed the styling to match. 
- Moved 'x' icon to be within the new div containers.
 
## Side effects

- None expected

## QA Notes

- When a user adds a new sub-discipline to the list, all listed items already selected will have an arrow at the end unless they are the last item in the list.

- In the case that the screen size is too small to fit all items in the list on one line, they will break up and move to the next line in order to fit.
<img width="592" alt="screen shot 2017-02-21 at 10 21 58 am" src="https://cloud.githubusercontent.com/assets/19379783/23171333/2f6c8cea-f820-11e6-9551-026b6a3a4c83.png">

- If the screen is too small to fit the individual elements on one line, the internal text will wrap to another line to fit.
<img width="449" alt="screen shot 2017-02-21 at 10 22 26 am" src="https://cloud.githubusercontent.com/assets/19379783/23171346/3ae891c2-f820-11e6-836b-f237826fc68d.png">

- When this happens, the side arrow _will not_ increase it's size to match the new height of the container.  This is expected behavior.