### PR TITLE
Feature/Submit Page Contributors New Tab [EOSF-503]

### DIFF
--- a/app/templates/components/preprint-form-authors.hbs
+++ b/app/templates/components/preprint-form-authors.hbs
@@ -121,7 +121,7 @@
                                         {{#if contrib.unregisteredContributor}}
                                             {{contrib.unregisteredContributor}}
                                         {{else}}
-                                            <a href={{contrib.users.links.html}}> {{contrib.users.fullName}} </a>
+                                            <a href={{contrib.users.links.html}} target="_blank"> {{contrib.users.fullName}} </a>
                                         {{/if}}
                                         <span class="pull-right remove-contributor-padding-xs">
                                             {{#if (and (permissionToRemoveContributor contrib currentUser isAdmin node) (conditionsForContribRemoval contrib contributors authorModification))}}
@@ -138,7 +138,7 @@
                                     {{#if contrib.unregisteredContributor}}
                                         {{contrib.unregisteredContributor}}
                                     {{else}}
-                                        <a href={{contrib.users.links.html}}> {{contrib.users.fullName}} </a>
+                                        <a href={{contrib.users.links.html}} target="_blank"> {{contrib.users.fullName}} </a>
                                     {{/if}}
                                 </div>
                             </td>

--- a/app/templates/components/preprint-form-authors.hbs
+++ b/app/templates/components/preprint-form-authors.hbs
@@ -23,7 +23,7 @@
                             <tr id={{result.id}}>
                                 <td class="p-v-xs">
                                     <img class="m-l-xs" src={{result.links.profile_image}} height=30 width=30>
-                                    <a href={{result.links.html}}> {{result.fullName}} </a>
+                                    <a href={{result.links.html}} target="_blank"> {{result.fullName}} </a>
                                     {{#if (eq currentUser result)}}
                                         <span class="small"> {{t "components.preprint-form-authors.yourself"}} </span>
                                     {{/if}}


### PR DESCRIPTION
## Ticket

https://openscience.atlassian.net/browse/EOSF-503

## Purpose

If a user is in the Create a Preprint flow and clicks on a contributors name, the user is taken to the user's profile page. If the user hits the back button, s/he is returned to the create a preprint flow but at the beginning of the process. There is no way for the user to return to the draft state or complete the preprint. This creates a poor user experience.
We should open the contributor profile in a new tab to prevent this.

## Changes

Open contributor links in a new tab on Submit page.  This includes links in search results as well as links for current contributors.  Also applies in mobile view.

## Side effects

<!--Any possible side effects? -->



