### PR TITLE
[EOSF-508] Increase caret(s) size for preprint provider carousel

### DIFF
--- a/app/styles/app.scss
+++ b/app/styles/app.scss
@@ -113,6 +113,15 @@ ul.comma-list {
     color: black;
 }
 
+@media (max-width: 768px) {
+    #providerCarousel {
+        .carousel-control .icon-next, .carousel-control .icon-prev {
+            margin-top: -30px;
+            font-size: 50px;
+        }
+    }
+}
+
 /* Main header with search bar */
 .preprint-header{
     background:#214661 url('img/preprints-bg.jpg') top center ;


### PR DESCRIPTION
<!-- Before submit your Pull Request, make sure you picked
     the right branch:

     - For hotfixes, select "master" as the target branch
     - For new features, select "develop" as the target branch
     - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch -->

## Ticket

https://openscience.atlassian.net/browse/EOSF-508

## Purpose

On mobile, the carets on the preprints provider carousel are very small.  This ticket fixes the size issue on mobile devices.

## Changes

All changes were done in CSS to increase the size of the carets and change the top margin to fit the new size.

## Side effects