### PR TITLE
Feature/Unregistered Contributors on Content Page [EOSF-462]

### DIFF
--- a/app/styles/app.scss
+++ b/app/styles/app.scss
@@ -338,7 +338,7 @@ ul.preprints-block-list {
         padding-top: 90px;
     }
     .view-authors {
-        color: #337ab7;
+        color: white;
         a {
             color: #6dd1de;
         }

--- a/app/templates/content.hbs
+++ b/app/templates/content.hbs
@@ -11,7 +11,11 @@
                             {{#if authors}}
                                 {{#each authors as |author index| ~}}
                                     {{#if author.bibliographic}}
-                                        <li><a href={{author.users.profileURL}} {{action 'click' 'link' 'Content - Author' author.users.profileURL}}>{{author.users.givenName}} {{author.users.familyName}}</a></li>
+                                        {{#if author.unregisteredContributor}}
+                                            <li>{{author.unregisteredContributor}}</li>
+                                        {{else}}
+                                            <li><a href={{author.users.profileURL}} {{action 'click' 'link' 'Content - Author' author.users.profileURL}}>{{author.users.givenName}} {{author.users.familyName}}</a></li>
+                                        {{/if}}
                                     {{/if}}
                                 {{~/each}}
                             {{else}}


### PR DESCRIPTION
## Ticket

https://openscience.atlassian.net/browse/EOSF-462

## Purpose

We should not be linking to unregistered contributor profile pages.  

## Changes

FIx this on the content page so there is no link if user hasn't confirmed their account.


## Current Appearance
![screen shot 2017-02-14 at 2 08 36 pm](https://cloud.githubusercontent.com/assets/9755598/22944576/20e53700-f2bf-11e6-9a94-985f22afd1cf.png)

## Side effects

<!--Any possible side effects? -->



