### PR TITLE
[EOSF-501] Improve Preprint download count wrapping

### DIFF
--- a/app/styles/app.scss
+++ b/app/styles/app.scss
@@ -113,6 +113,16 @@ ul.comma-list {
     color: black;
 }
 
+#downloadCount {
+    display: inline-block;
+}
+
+@media (max-width: 991px) {
+    .download_project, .social-div {
+        width: auto;
+    }
+}
+
 @media (max-width: 768px) {
     #providerCarousel {
         .carousel-control .icon-next, .carousel-control .icon-prev {
@@ -1195,6 +1205,7 @@ label.title-label {
     float: none !important;
     white-space: nowrap;
 }
+
 .social-div {
     margin-top: 5px;
 }

--- a/app/templates/content.hbs
+++ b/app/templates/content.hbs
@@ -66,10 +66,10 @@
             {{#unless fullScreenMFR}}
                 <div class="col-md-5"> {{!RIGHT SIDE COL}}
                     <div class="share-row p-sm osf-box-lt clearfix">{{!SHARE ROW}}
-                        <div class="row" id="download_project clearfix">
-                            <div class="col-xs-12 col-lg-8">
+                        <div class="row clearfix">
+                            <div class="col-xs-12 col-lg-8 download_project">
                                 <a class="btn btn-primary" href={{fileDownloadURL}} onclick={{action 'click' 'link' 'Preprints - Content - Download'}}>{{t "content.share.download_preprint"}}</a>
-                                <span class="p-md">{{t "content.share.downloads"}}: {{model.primaryFile.extra.downloads}}</span>
+                                <span class="p-sm" id="downloadCount">{{t "content.share.downloads"}}: {{model.primaryFile.extra.downloads}}</span>
                             </div>
                             <div class="col-xs-12 col-lg-4 social-div">
                                 <span class="p-xs pull-right social-media-icons">


### PR DESCRIPTION
<!-- Before submit your Pull Request, make sure you picked
     the right branch:

     - For hotfixes, select "master" as the target branch
     - For new features, select "develop" as the target branch
     - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch -->

## Ticket

https://openscience.atlassian.net/browse/EOSF-501

## Purpose

The download count for a preprint was breaking to the next line before the share icons.  This ticket fixes this issue.

## Changes

Added a new class to both containers in order to remove the original template styling for the width of each container.

## Screenshots 

<b>BEFORE</b>
Before changes, the download count would wrap to the next line before the icons next to it.  This could be confusing to users who expect to see the number of downloads next to the label.
![screenshot 2017-02-08 13 52 57](https://cloud.githubusercontent.com/assets/19379783/23714588/d0758d98-03f7-11e7-9ecb-b7e8723fabeb.png)

<hr>
<b>AFTER</b><br>
After changes, the download count remains on the same line as the rest of the text. 
<img width="1440" alt="screen shot 2017-03-08 at 12 26 05 pm" src="https://cloud.githubusercontent.com/assets/19379783/23715397/7f5608b8-03fa-11e7-9f6f-35542ad9e74c.png">


When the screen becomes too small to fit everything on one line, the icons are the first to move to the next line underneath the "Download preprint" button.
<img width="1199" alt="screen shot 2017-03-08 at 12 27 16 pm" src="https://cloud.githubusercontent.com/assets/19379783/23715435/a4141bc2-03fa-11e7-83fa-a335f3931378.png">




## Notes to QA
Because CSS can potentially act differently across browsers, please be sure to test this on different browsers to make sure that there aren't any abnormalities.  