### PR TITLE
[hotfix] [EOSF-514] Use providers list from APIv2 instead of hardcoded list

### DIFF
--- a/app/controllers/discover.js
+++ b/app/controllers/discover.js
@@ -1,6 +1,5 @@
 import Ember from 'ember';
 import config from 'ember-get-config';
-import loadAll from 'ember-osf/utils/load-relationship';
 import Analytics from '../mixins/analytics';
 
 import { elasticEscape } from '../utils/elastic-query';


### PR DESCRIPTION
## Ticket

https://openscience.atlassian.net/browse/EOSF-514

## Purpose

Updates the discover route so that Preprint Providers in from the API are used in the whitelist (not hardcoded)

## Changes

/preprints/discover (OSF Preprints only) should now have all of the providers available. Providers in the API, but not in SHARE will be displayed with with a document count of 0.
![screen shot 2017-02-15 at 13 55 35](https://cloud.githubusercontent.com/assets/3374510/22990224/7abfd3b2-f386-11e6-9af5-ba7337ffbb61.png)


## Side effects

Providers should now load automatically when added to the API

<!--Any possible side effects? -->



