### PR TITLE
Render Preprints without licenses [EOSF-526]

### DIFF
--- a/app/routes/content.js
+++ b/app/routes/content.js
@@ -127,6 +127,8 @@ export default Ember.Route.extend(Analytics, ResetScrollMixin, SetupSubmitContro
                 const imageUrl = `${origin.replace(/^https/, 'http')}${image.path}`;
                 const dateCreated = new Date(preprint.get('dateCreated') || null);
                 const dateModified = new Date(preprint.get('dateModified') || dateCreated);
+                if (!preprint.get('datePublished'))
+                    preprint.set('datePublished', dateCreated);
                 const providerName = provider.get('name');
                 const canonicalUrl = preprint.get('links.html');
 
@@ -204,11 +206,17 @@ export default Ember.Route.extend(Analytics, ResetScrollMixin, SetupSubmitContro
                 }
 
                 highwirePress.push(['citation_publisher', providerName]);
-                dublinCore.push(
-                    ['dc.publisher', providerName],
-                    ['dc.license', license.get('name')]
-                );
-
+                if (license) {
+                    dublinCore.push(
+                        ['dc.publisher', providerName],
+                        ['dc.license', license.get('name')]
+                    );
+                } else {
+                    dublinCore.push(
+                        ['dc.publisher', providerName],
+                        ['dc.license', 'No licence']
+                    );
+                }
                 if (/\.pdf$/.test(primaryFile.get('name'))) {
                     highwirePress.push(['citation_pdf_url', primaryFile.get('links').download]);
                 }


### PR DESCRIPTION
## Ticket

https://openscience.atlassian.net/browse/EOSF-526 

## Purpose

Unable to Render Preprints without licenses.

## Changes
This was caused by trying to retrieve the name attribute from the license, which in this case equals to null. Added a check to handle the null value.

Noticed that for preprints in this case, once loaded, the dataPublished is equal to null too, causing a warning with the moment-format helper.  Added another check to handle this situation.


## Side effects

<!--Any possible side effects? -->



