### PR TITLE
Clear search box text when navigating away from page [EOSF-494]

### DIFF
--- a/app/controllers/discover.js
+++ b/app/controllers/discover.js
@@ -330,6 +330,10 @@ export default Ember.Controller.extend(Analytics, {
         });
     },
 
+    _clearQueryString() {
+        this.set('queryString', '');
+    },
+
     otherProviders: [],
     actions: {
         search(val, event) {
@@ -381,6 +385,10 @@ export default Ember.Controller.extend(Analytics, {
                     action: 'click',
                     label: 'Preprints - Discover - Clear Filters'
                 });
+        },
+
+        clearQueryString() {
+            this._clearQueryString();
         },
 
         sortBySelect(index) {

--- a/app/controllers/discover.js
+++ b/app/controllers/discover.js
@@ -387,10 +387,6 @@ export default Ember.Controller.extend(Analytics, {
                 });
         },
 
-        clearQueryString() {
-            this._clearQueryString();
-        },
-
         sortBySelect(index) {
             // Selecting an option just swaps it with whichever option is first
             let copy = this.get('sortByOptions').slice(0);

--- a/app/routes/discover.js
+++ b/app/routes/discover.js
@@ -27,6 +27,7 @@ export default Ember.Route.extend(Analytics, ResetScrollMixin, {
         willTransition() {
             let controller = this.controllerFor('discover');
             controller._clearFilters();
+            controller._clearQueryString();
         }
     }
 });


### PR DESCRIPTION
## Ticket

https://openscience.atlassian.net/browse/EOSF-494 

## Purpose
This is a follow-up to EOSF-426, which clears selected filters when navigating away from the preprints search page. However, it does NOT clear text entered into the search box. 

This ticket is to clear the text entered in the search box.

<!-- Describe the purpose of your changes -->

## Changes
 - Defined a new method within the controller to clear the search box.
 - Call the new method from the existing willTransition method inside discover.js

## Side effects

<!--Any possible side effects? -->



