### PR TITLE
[EOSF-529] Hide random hour of the day timestamp on Preprints

### DIFF
--- a/app/templates/components/search-result.hbs
+++ b/app/templates/components/search-result.hbs
@@ -25,7 +25,7 @@
                 </div>
 
                 {{!Added on}}
-                <div class="m-t-sm"> <em> {{t "global.added_on"}}: {{moment-format result.date}} </em> </div>
+                <div class="m-t-sm"> <em> {{t "global.added_on"}}: {{moment-format result.date "YYYY-MM-DD"}} </em> </div>
 
                 {{#if result.subjects}}
                     <div class="m-t-sm">


### PR DESCRIPTION
<!-- Before submit your Pull Request, make sure you picked
     the right branch:

     - For hotfixes, select "master" as the target branch
     - For new features, select "develop" as the target branch
     - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch -->

## Ticket

https://openscience.atlassian.net/browse/EOSF-529

## Purpose

SHARE isn't able to get a timestamp from most providers, which means that some of the timestamps in Ember Preprints and Registries are randomly assigned.  The purpose of this ticket is to remove the time portion of the timestamp from Preprints.

## Changes

Changes for this ticket include changing the format of the timestamp to only be in "YYYY-MM-DD" format, leaving out the time.

## Screenshots

Originally, the 'Added on' date for Preprints would show the time in addition to the date.
<img width="1440" alt="screen shot 2017-03-10 at 12 39 50 pm" src="https://cloud.githubusercontent.com/assets/19379783/23806308/2fadcb34-058f-11e7-8f10-efedd5f496ff.png">

<br>

After the changes, the 'Added on' date now only shows the date without the time.
<img width="1440" alt="screen shot 2017-03-10 at 12 41 19 pm" src="https://cloud.githubusercontent.com/assets/19379783/23806327/43994d26-058f-11e7-8763-5f6d77adf9fc.png">