### PR TITLE
[EOSF-528] Fixed order on Preprints Search sort

### DIFF
--- a/app/controllers/discover.js
+++ b/app/controllers/discover.js
@@ -51,15 +51,15 @@ export default Ember.Controller.extend(Analytics, {
     queryBody: {},
     providersPassed: false,
     pageNumbers: [],
-    staticSortOptions: ['Relevance', 'Upload date (oldest to newest)', 'Upload date (newest to oldest)'],
     sortByOptions: ['Relevance', 'Upload date (oldest to newest)', 'Upload date (newest to oldest)'],
+    selectedSortByOption: '',
 
     treeSubjects: Ember.computed('activeFilters', function() {
         return this.get('activeFilters.subjects').slice();
     }),
-    // chosenOption is always the first element in the list
-    chosenSortByOption: Ember.computed('sortByOptions', function() {
-        return this.get('sortByOptions')[0];
+    // chosenSortByOption is going to be the last selected element, or if it's a new page then it's the first in the list
+    chosenSortByOption: Ember.computed('selectedSortByOption', function() {
+        return this.get('selectedSortByOption') === '' ? this.get('sortByOptions')[0] : this.get('selectedSortByOption');
     }),
 
     showActiveFilters: true, //should always have a provider, don't want to mix osfProviders and non-osf
@@ -294,12 +294,11 @@ export default Ember.Controller.extend(Analytics, {
             });
         }
 
-        const sortByOption = this.get('chosenSortByOption');
         const sort = {};
 
-        if (sortByOption === 'Upload date (oldest to newest)') {
+        if (this.get('selectedSortByOption') === 'Upload date (oldest to newest)') {
             sort.date_updated = 'asc';
-        } else if (sortByOption === 'Upload date (newest to oldest)') {
+        } else if (this.get('selectedSortByOption') === 'Upload date (newest to oldest)') {
             sort.date_updated = 'desc';
         }
 
@@ -385,12 +384,8 @@ export default Ember.Controller.extend(Analytics, {
         },
 
         sortBySelect(index) {
-            // Selecting an option just swaps it with whichever option is first
-            let copy = this.get('staticSortOptions').slice(0);
-            let temp = copy[0];
-            copy[0] = copy[index];
-            copy[index] = temp;
-            this.set('sortByOptions', copy);
+            // sets the variable for the selected option and reloads the page
+            this.set('selectedSortByOption', this.get('sortByOptions')[index]);
             this.set('page', 1);
             this.loadPage();
 
@@ -398,7 +393,7 @@ export default Ember.Controller.extend(Analytics, {
                 .trackEvent({
                     category: 'dropdown',
                     action: 'select',
-                    label: `Preprints - Discover - Sort by: ${this.get('staticSortOptions')[index]}`
+                    label: `Preprints - Discover - Sort by: ${this.get('sortByOptions')[index]}`
                 });
         },
 

--- a/app/controllers/discover.js
+++ b/app/controllers/discover.js
@@ -66,7 +66,7 @@ export default Ember.Controller.extend(Analytics, {
     }),
     // chosenSortByOption is going to be the last selected element, or if it's a new page then it's the first in the list
     chosenSortByOption: Ember.computed('sortByOption', function() {
-        return this.get('sortByOption') === '' ? this.get('sortByOptions')[0] : this.get('sortByOption');
+        return this.get('sortByOption') || this.get('sortByOptions')[0];
     }),
 
     showActiveFilters: true, //should always have a provider, don't want to mix osfProviders and non-osf
@@ -303,10 +303,11 @@ export default Ember.Controller.extend(Analytics, {
 
         const sort = {};
         const i18n = this.get('i18n');
+        const sortByOption = this.get('sortByOption').toString();
 
-        if (this.get('sortByOption').toString() === i18n.t('discover.sort_oldest_newest').toString()) {
+        if (sortByOption.toString() === i18n.t('discover.sort_oldest_newest').toString()) {
             sort.date_updated = 'asc';
-        } else if (this.get('sortByOption').toString() === i18n.t('discover.sort_newest_oldest').toString()) {
+        } else if (sortByOption.toString() === i18n.t('discover.sort_newest_oldest').toString()) {
             sort.date_updated = 'desc';
         }
 

--- a/app/controllers/discover.js
+++ b/app/controllers/discover.js
@@ -305,9 +305,9 @@ export default Ember.Controller.extend(Analytics, {
         const i18n = this.get('i18n');
         const sortByOption = this.get('sortByOption').toString();
 
-        if (sortByOption.toString() === i18n.t('discover.sort_oldest_newest').toString()) {
+        if (sortByOption === i18n.t('discover.sort_oldest_newest').toString()) {
             sort.date_updated = 'asc';
-        } else if (sortByOption.toString() === i18n.t('discover.sort_newest_oldest').toString()) {
+        } else if (sortByOption === i18n.t('discover.sort_newest_oldest').toString()) {
             sort.date_updated = 'desc';
         }
 

--- a/app/controllers/discover.js
+++ b/app/controllers/discover.js
@@ -51,6 +51,7 @@ export default Ember.Controller.extend(Analytics, {
     queryBody: {},
     providersPassed: false,
     pageNumbers: [],
+    staticSortOptions: ['Relevance', 'Upload date (oldest to newest)', 'Upload date (newest to oldest)'],
     sortByOptions: ['Relevance', 'Upload date (oldest to newest)', 'Upload date (newest to oldest)'],
 
     treeSubjects: Ember.computed('activeFilters', function() {
@@ -385,7 +386,7 @@ export default Ember.Controller.extend(Analytics, {
 
         sortBySelect(index) {
             // Selecting an option just swaps it with whichever option is first
-            let copy = this.get('sortByOptions').slice(0);
+            let copy = this.get('staticSortOptions').slice(0);
             let temp = copy[0];
             copy[0] = copy[index];
             copy[index] = temp;
@@ -397,7 +398,7 @@ export default Ember.Controller.extend(Analytics, {
                 .trackEvent({
                     category: 'dropdown',
                     action: 'select',
-                    label: `Preprints - Discover - Sort by: ${copy[index]}`
+                    label: `Preprints - Discover - Sort by: ${this.get('staticSortOptions')[index]}`
                 });
         },
 

--- a/app/styles/app.scss
+++ b/app/styles/app.scss
@@ -320,15 +320,27 @@ ul.preprints-block-list {
     list-style: none;
     padding-left: 0;
 }
-.dropdown {
-    #sortBy {
-        width: 291px;
-    }
-    .dropdown-menu {
-        width: 291px;
-    }
+
+#sortBy {
+    min-width: 291px;
+    width: 100%;
 }
 
+#sortByOptionList {
+    background-color: #EFEFEF;
+    min-width: 291px;
+    .listOption {
+        cursor: pointer;
+        a {
+            text-decoration: none;
+            color: black;
+        }
+        a:hover {
+            background-image: none;
+            background-color: #D9D9D9;
+        }
+    }
+}
 
 /* VIEW page */
 

--- a/app/styles/app.scss
+++ b/app/styles/app.scss
@@ -340,27 +340,10 @@ ul.preprints-block-list {
     padding-left: 0;
 }
 
-#sortBy {
-    min-width: 291px;
-    width: 100%;
+.listOption:hover {
+    cursor: pointer;
+    color: rgba(255, 255, 255, 0.8) !important;
 }
-
-#sortByOptionList {
-    background-color: #EFEFEF;
-    min-width: 291px;
-    .listOption {
-        cursor: pointer;
-        a {
-            text-decoration: none;
-            color: black;
-        }
-        a:hover {
-            background-image: none;
-            background-color: #D9D9D9;
-        }
-    }
-}
-
 /* VIEW page */
 
 .dark-overlay-header-background {

--- a/app/styles/app.scss
+++ b/app/styles/app.scss
@@ -320,6 +320,14 @@ ul.preprints-block-list {
     list-style: none;
     padding-left: 0;
 }
+.dropdown {
+    #sortBy {
+        width: 291px;
+    }
+    .dropdown-menu {
+        width: 291px;
+    }
+}
 
 
 /* VIEW page */

--- a/app/templates/discover.hbs
+++ b/app/templates/discover.hbs
@@ -49,7 +49,7 @@
                             <span class="caret"></span>
                         </button>
                         <ul class="dropdown-menu" aria-labelledby="sortBy" id="sortByOptionList">
-                            {{#each staticSortOptions as |option index|}}
+                            {{#each sortByOptions as |option index|}}
                                 <li class="listOption"><a {{action "sortBySelect" index}}>{{option}}</a></li>
                             {{/each}}
                         </ul>

--- a/app/templates/discover.hbs
+++ b/app/templates/discover.hbs
@@ -49,7 +49,7 @@
                             <span class="caret"></span>
                         </button>
                         <ul class="dropdown-menu" aria-labelledby="sortBy">
-                            {{#each sortByOptions as |option index|}}
+                            {{#each staticSortOptions as |option index|}}
                                 <li style="cursor: pointer; cursor: hand"><a {{action "sortBySelect" index}}>{{option}}</a></li>
                             {{/each}}
                         </ul>

--- a/app/templates/discover.hbs
+++ b/app/templates/discover.hbs
@@ -48,9 +48,9 @@
                             {{t "discover.sort_by"}}: {{chosenSortByOption}}
                             <span class="caret"></span>
                         </button>
-                        <ul class="dropdown-menu" aria-labelledby="sortBy" id="sortByOptionList">
+                        <ul class="dropdown-menu dropdown-menu-right" aria-labelledby="sortBy">
                             {{#each sortByOptions as |option index|}}
-                                <li class="listOption"><a {{action "sortBySelect" index}}>{{option}}</a></li>
+                                <li><a class="listOption" {{action "sortBySelect" index}}>{{option}}</a></li>
                             {{/each}}
                         </ul>
                     </div>

--- a/app/templates/discover.hbs
+++ b/app/templates/discover.hbs
@@ -48,9 +48,9 @@
                             {{t "discover.sort_by"}}: {{chosenSortByOption}}
                             <span class="caret"></span>
                         </button>
-                        <ul class="dropdown-menu" aria-labelledby="sortBy">
+                        <ul class="dropdown-menu" aria-labelledby="sortBy" id="sortByOptionList">
                             {{#each staticSortOptions as |option index|}}
-                                <li style="cursor: pointer; cursor: hand"><a {{action "sortBySelect" index}}>{{option}}</a></li>
+                                <li class="listOption"><a {{action "sortBySelect" index}}>{{option}}</a></li>
                             {{/each}}
                         </ul>
                     </div>


### PR DESCRIPTION
<!-- Before submit your Pull Request, make sure you picked
     the right branch:

     - For hotfixes, select "master" as the target branch
     - For new features, select "develop" as the target branch
     - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch -->

## Ticket

https://openscience.atlassian.net/browse/EOSF-528

## Purpose

The order of sorting in Preprints would change based on what the user selects.  The order of the list should stay consistent regardless of what is selected.  

## Changes and Screenshots

The list of available sources a user can choose from is static and doesn't change regardless of what's chosen.  

The main style aspect that was changed was to make the font of the dropdown better match the style of other dropdowns on the site (mainly the navbar).  The alignment of the dropdown list was changed to be anchored on the right to match its position on the page.  When you hover over the choices, the background of the list element changes to a slightly lighter color, and the font gets a bit darker.
<img width="1440" alt="screen shot 2017-03-30 at 2 50 34 pm" src="https://cloud.githubusercontent.com/assets/19379783/24521050/b27ba5e4-1558-11e7-8cd6-8fc499efd68d.png">

And when you select something from the list, the order of the list will stay the same regardless of what you chose:
<img width="1440" alt="screen shot 2017-03-30 at 2 51 02 pm" src="https://cloud.githubusercontent.com/assets/19379783/24521087/d3c2c35e-1558-11e7-841c-719bdb60fc86.png">

## Notes to QA
Since this has some CSS changes, please be sure to test this in all browsers to make sure that there aren't any unexpected changes.

