### PR TITLE
[EOSF-531] Fix overlap on content view

### DIFF
--- a/app/styles/app.scss
+++ b/app/styles/app.scss
@@ -1105,6 +1105,10 @@ label.title-label {
     background-size: contain;
 }
 
+.supplemental-downloads {
+    text-align: right;
+}
+
 @media (max-width: 768px) {
     .edit-button-and-logo {
         padding-top: 20px;

--- a/app/templates/components/supplementary-file-browser.hbs
+++ b/app/templates/components/supplementary-file-browser.hbs
@@ -3,10 +3,10 @@
 {{/file-renderer}}
 
 <div class="row">
-    <div class="col-sm-8">
+    <div class="col-sm-6">
         <p class="f-w-lg p-b-md">{{selectedFile.name}}</p>
     </div>
-    <div class="col-sm-4 text-nowrap supplemental-downloads">
+    <div class="col-sm-6 text-nowrap supplemental-downloads">
         {{#if (eq selectedFile.id preprint.primaryFile.id)}}
             <a class="btn btn-default btn-sm" href={{fileDownloadURL}} onclick={{action 'click' 'link' 'Preprints - Content - Download'}}> {{t "content.share.download_preprint"}}</a>
         {{else}}


### PR DESCRIPTION
## Ticket

https://openscience.atlassian.net/browse/EOSF-531

## Purpose

Content on the preprints content view overflows into the citations section when the browser window width is between 990px and 1200px.

## Changes

Updates the bootstrap classes and stylesheet

### Before
<img width="979" alt="screen shot 2017-03-06 at 15 18 01" src="https://cloud.githubusercontent.com/assets/3374510/23628001/dc7e3c8e-0280-11e7-94ff-5392a457d0d2.png">

### After
<img width="1035" alt="screen shot 2017-03-06 at 15 18 46" src="https://cloud.githubusercontent.com/assets/3374510/23628014/e40df304-0280-11e7-943c-22b934f91bcd.png">

## Side effects

N/A



