### PR TITLE
[Hotfix] [EOSF-552] update meta tags for Google Scholar

### DIFF
--- a/app/routes/content.js
+++ b/app/routes/content.js
@@ -206,23 +206,22 @@ export default Ember.Route.extend(Analytics, ResetScrollMixin, SetupSubmitContro
                 }
 
                 highwirePress.push(['citation_publisher', providerName]);
-                if (license) {
-                    dublinCore.push(
-                        ['dc.publisher', providerName],
-                        ['dc.license', license.get('name')]
-                    );
-                } else {
-                    dublinCore.push(
-                        ['dc.publisher', providerName],
-                        ['dc.license', 'No licence']
-                    );
-                }
+                dublinCore.push(
+                    ['dc.publisher', providerName],
+                    ['dc.license', license ? license.get('name') : 'No license']
+                );
+
                 if (/\.pdf$/.test(primaryFile.get('name'))) {
                     highwirePress.push(['citation_pdf_url', primaryFile.get('links').download]);
                 }
 
-                const headTags = [
-                    openGraph,
+                const openGraphTags = openGraph
+                    .map(([property, content]) => ({
+                        property,
+                        content
+                    }));
+
+                const googleScholarTags = [
                     highwirePress,
                     eprints,
                     bePress,
@@ -230,13 +229,19 @@ export default Ember.Route.extend(Analytics, ResetScrollMixin, SetupSubmitContro
                     dublinCore
                 ]
                     .reduce((a, b) => a.concat(b), [])
-                    .filter(item => item[1]) // Don't show tags with no content
-                    .map(item => ({
+                    .map(([name, content]) => ({
+                        name,
+                        content
+                    }));
+
+                const headTags = [
+                    ...openGraphTags,
+                    ...googleScholarTags
+                ]
+                    .filter(({content}) => content) // Only show tags with content
+                    .map(attrs => ({
                         type: 'meta',
-                        attrs: {
-                            property: item[0],
-                            content: item[1]
-                        }
+                        attrs
                     }));
 
                 this.set('headTags', headTags);


### PR DESCRIPTION
## Ticket

https://openscience.atlassian.net/browse/EOSF-552

## Purpose

Needed for Google Scholar to index preprints

## Changes

Changes the `property` attribute to `name` on non-open graph meta tags on the content route

### Before
<img width="1063" alt="screen shot 2017-03-09 at 11 23 56" src="https://cloud.githubusercontent.com/assets/3374510/23760054/894ac4a4-04bc-11e7-9339-e63d4f6d1ba2.png">

### After
<img width="1067" alt="screen shot 2017-03-09 at 11 22 41" src="https://cloud.githubusercontent.com/assets/3374510/23760061/8d25de7e-04bc-11e7-82d9-1030f684f5c4.png">

## Side effects

N/A



