### PR TITLE
[EOSF-498] Dockerfile adds ember-osf destination folder

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -36,6 +36,7 @@ RUN cd /tmp \
     && mv watchman /usr/local/bin/watchman \
     && rm -Rf /tmp/watchman
 
+RUN mkdir -p /ember-osf
 RUN mkdir -p /code
 WORKDIR /code
 


### PR DESCRIPTION
## Ticket
https://openscience.atlassian.net/browse/EOSF-498

## Purpose
To create a destination for data volume containing local version of ember-osf, for ember-osf/ember-preprints development.

## Changes
Adds /ember-osf folder to root of preprints container.

## Side effects
If not using it for local ember-osf development, creates an empty folder



