### PR TITLE
[Hotfix] [EOSF-555] Prerender full abstract

### DIFF
--- a/app/controllers/content.js
+++ b/app/controllers/content.js
@@ -56,7 +56,7 @@ export default Ember.Controller.extend(Analytics, {
     expandedAuthors: true,
     showLicenseText: false,
     fileDownloadURL: '',
-    expandedAbstract: false,
+    expandedAbstract: navigator.userAgent.includes('Prerender'),
     isAdmin: Ember.computed('node', function() {
         // True if the current user has admin permissions for the node that contains the preprint
         return (this.get('node.currentUserPermissions') || []).includes(permissions.ADMIN);
@@ -145,19 +145,18 @@ export default Ember.Controller.extend(Analytics, {
         });
     }),
 
-    useShortenedDescription: Ember.computed('node.description', function() {
-        return this.get('node.description') ? this.get('node.description').length > 350 : false;
+    hasShortenedDescription: Ember.computed('node.description', function() {
+        const nodeDescription = this.get('node.description');
+
+        return nodeDescription && nodeDescription.length > 350;
     }),
 
     description: Ember.computed('node.description', 'expandedAbstract', function() {
         // Get a shortened version of the abstract, but doesnt cut in the middle of word by going
         // to the last space.
-        if (this.get('expandedAbstract')) {
-            return this.get('node.description');
-        }
-        let text = this.get('node.description').slice(0, 350).split(' ');
-        text.pop();
-        return text.join(' ') + ' ...';
+        return this.get('node.description')
+            .slice(0, 350)
+            .replace(/\s+\S*$/, '');
     }),
 
     actions: {

--- a/app/locales/en/translations.js
+++ b/app/locales/en/translations.js
@@ -47,6 +47,8 @@ export default {
             download_file: `Download file`,
             download_preprint: `Download preprint`
         },
+        see_more: 'See more',
+        see_less: 'See less',
         version: 'Version',
         article_doi: `Article DOI`,
         citations: `Citations`,

--- a/app/styles/app.scss
+++ b/app/styles/app.scss
@@ -363,6 +363,9 @@ ul.preprints-block-list {
     .abstract {
         white-space: pre-line;
     }
+    .abstract-truncated:after {
+        content: ' \2026';
+    }
     .project-box {
         div {
             min-height: 100px;

--- a/app/templates/content.hbs
+++ b/app/templates/content.hbs
@@ -83,12 +83,8 @@
                     </div>
                     <div class="p-t-xs">
                         <h4 class="p-v-md f-w-md"><strong>{{t "global.abstract"}}</strong></h4>
-                        {{#if useShortenedDescription}}
-                            <p class="abstract">{{description}}</p>
-                            <button class='btn-link' {{action 'expandAbstract'}}>{{if expandedAbstract 'See less' 'See more'}}</button>
-                        {{else}}
-                            <p class="abstract">{{node.description}}</p>
-                        {{/if}}
+                        <p class="abstract {{unless expandedAbstract 'abstract-truncated'}}">{{if expandedAbstract node.description description}}</p>
+                        <button class='btn-link' hidden={{not hasShortenedDescription}} {{action 'expandAbstract'}}>{{t (if expandedAbstract 'content.see_less' 'content.see_more')}}</button>
                     </div>
 
                     {{#if model.doi}}


### PR DESCRIPTION
## Ticket

https://openscience.atlassian.net/browse/EOSF-555

## Purpose

Needed for Google Scholar to index the page properly

## Changes

* Sets `expandedAbstract` to true by default if the user agent contains `Prerender` (per the [Prerender docs](https://prerender.io/documentation/faq))
* Simplifies the description property
* Use CSS for the ellipses
* Move strings to translation file
* Hides the show more/show less button if the the description the shortened description is less than 350 characters

## Side effects

N/A



