### PR TITLE
Update the language for "sort by options" and "added on" field [EOSF-438]

### DIFF
--- a/app/controllers/discover.js
+++ b/app/controllers/discover.js
@@ -50,8 +50,15 @@ export default Ember.Controller.extend(Analytics, {
     subjectFilter: null,
     queryBody: {},
     providersPassed: false,
+
+    i18n: Ember.inject.service(),
+
+    sortByOptions: Ember.computed('i18n.locale', function() {
+        const i18n = this.get('i18n');
+        return [i18n.t('discover.relevance'), i18n.t('discover.sort_oldest_newest'), i18n.t('discover.sort_newest_oldest')];
+    }),
+
     pageNumbers: [],
-    sortByOptions: ['Relevance', 'Upload date (oldest to newest)', 'Upload date (newest to oldest)'],
 
     treeSubjects: Ember.computed('activeFilters', function() {
         return this.get('activeFilters.subjects').slice();
@@ -296,9 +303,10 @@ export default Ember.Controller.extend(Analytics, {
         const sortByOption = this.get('chosenSortByOption');
         const sort = {};
 
-        if (sortByOption === 'Upload date (oldest to newest)') {
+        const i18n = this.get('i18n');
+        if (sortByOption.toString() === i18n.t('discover.sort_oldest_newest').toString()) {
             sort.date_updated = 'asc';
-        } else if (sortByOption === 'Upload date (newest to oldest)') {
+        } else if (sortByOption.toString() === i18n.t('discover.sort_newest_oldest').toString()) {
             sort.date_updated = 'desc';
         }
 

--- a/app/locales/en/translations.js
+++ b/app/locales/en/translations.js
@@ -70,6 +70,10 @@ export default {
             placeholder: `Search preprints...`
         },
         sort_by: `Sort by`,
+        sort_newest_oldest: `Modified Date (newest to oldest)`,
+        sort_oldest_newest: `Modified Date (oldest to newest)`,
+        modified_on: `Modified on`,
+        relevance: `Relevance`,
         main: {
             active_filters: {
                 heading: `Active Filters`,

--- a/app/templates/components/search-result.hbs
+++ b/app/templates/components/search-result.hbs
@@ -24,8 +24,8 @@
                     </ul>
                 </div>
 
-                {{!Added on}}
-                <div class="m-t-sm"> <em> {{t "global.added_on"}}: {{moment-format result.date "YYYY-MM-DD"}} </em> </div>
+                {{!Last edited on}}
+                <div class="m-t-sm"> <em> {{t "content.header.last_edited"}}: {{moment-format result.date "YYYY-MM-DD"}} </em> </div>
 
                 {{#if result.subjects}}
                     <div class="m-t-sm">


### PR DESCRIPTION
## Ticket

https://openscience.atlassian.net/browse/EOSF-438

## Purpose

The "Date Added" dates are the dates the Preprint was created. The Sorting date, however, is really the Date Modified date. There should be consistency to meet user expectations.

## Changes

- Update the translation file. 
- Use the translation service.
- Rename sort buttons to "Sort by Modified Date (newest to oldest)" and "Sort by Modified Date (oldest to newest)"
- Update the "Added on" field to be "Last edited on"
