### PR TITLE
[Hotfix] [EOSF-555] Abstract Truncation take 2 🎬

### DIFF
--- a/app/controllers/content.js
+++ b/app/controllers/content.js
@@ -151,8 +151,12 @@ export default Ember.Controller.extend(Analytics, {
         return nodeDescription && nodeDescription.length > 350;
     }),
 
-    description: Ember.computed('node.description', 'expandedAbstract', function() {
-        // Get a shortened version of the abstract, but doesnt cut in the middle of word by going
+    useShortenedDescription: Ember.computed('expandedAbstract', 'hasShortenedDescription', function() {
+        return this.get('hasShortenedDescription') && !this.get('expandedAbstract');
+    }),
+
+    description: Ember.computed('node.description', function() {
+        // Get a shortened version of the abstract, but doesn't cut in the middle of word by going
         // to the last space.
         return this.get('node.description')
             .slice(0, 350)

--- a/app/templates/content.hbs
+++ b/app/templates/content.hbs
@@ -83,8 +83,12 @@
                     </div>
                     <div class="p-t-xs">
                         <h4 class="p-v-md f-w-md"><strong>{{t "global.abstract"}}</strong></h4>
-                        <p class="abstract {{unless expandedAbstract 'abstract-truncated'}}">{{if expandedAbstract node.description description}}</p>
-                        <button class='btn-link' hidden={{not hasShortenedDescription}} {{action 'expandAbstract'}}>{{t (if expandedAbstract 'content.see_less' 'content.see_more')}}</button>
+                        <p class="abstract {{if useShortenedDescription 'abstract-truncated'}}">
+                            {{~if useShortenedDescription description node.description~}}
+                        </p>
+                        <button class='btn-link' hidden={{not hasShortenedDescription}} {{action 'expandAbstract'}}>
+                            {{~t (if expandedAbstract 'content.see_less' 'content.see_more')~}}
+                        </button>
                     </div>
 
                     {{#if model.doi}}


### PR DESCRIPTION
## Ticket

https://openscience.atlassian.net/browse/EOSF-555

## Purpose

Last fix broke short abstracts

### Preprint with a short abstract
<img width="634" alt="screen shot 2017-03-21 at 15 01 06" src="https://cloud.githubusercontent.com/assets/3374510/24165630/472a8ca0-0e47-11e7-9030-c32f1e906a42.png">

Introduced in #300

![bitmoji](https://render.bitstrips.com/v2/cpanel/10216702-245828918_2-s1-v1.png?transparent=1&palette=1&width=246)

## Changes

This accounts for short abstracts

### Preprint with a short abstract
<img width="638" alt="screen shot 2017-03-21 at 14 56 26" src="https://cloud.githubusercontent.com/assets/3374510/24165506/f3656a4a-0e46-11e7-892e-d895c3d391ae.png">

### Preprint with a long abstract - collapsed
<img width="649" alt="screen shot 2017-03-21 at 14 56 53" src="https://cloud.githubusercontent.com/assets/3374510/24165507/f373f268-0e46-11e7-8d40-6780991529b3.png">

### Preprint with a long abstract - expanded
<img width="662" alt="screen shot 2017-03-21 at 14 57 01" src="https://cloud.githubusercontent.com/assets/3374510/24165508/f37d0a7e-0e46-11e7-9092-ee8d7a4e427b.png">


## Side effects

<!--Any possible side effects? -->



