### PR TITLE
Detecting Consuming Application in Ember-OSF (preprints) [EOSF-581]

### DIFF
--- a/config/environment.js
+++ b/config/environment.js
@@ -5,6 +5,7 @@ module.exports = function(environment) {
 
     var ENV = {
         modulePrefix: 'preprint-service',
+        appName: 'Preprints',
         environment: environment,
         rootURL: '/',
         locationType: 'auto',


### PR DESCRIPTION
## Ticket
https://openscience.atlassian.net/browse/EOSF-581

# Purpose
Sometimes in Ember-OSF, we need to know the consuming application - to handle things differently for preprints or registries.

A new entry appName is added to /config/envirnoment.js , this entry will be used to hold the app name. The new mixin in ember-osf will have an attribute the read this entry and used by the consuming component.
# Notes for Reviewers

## Routes Added/Updated

