### PR TITLE
[hotfix] Google Scholar citation_pdf_url

### DIFF
--- a/app/routes/content/index.js
+++ b/app/routes/content/index.js
@@ -7,7 +7,10 @@ import loadAll from 'ember-osf/utils/load-relationship';
 import permissions from 'ember-osf/const/permissions';
 import getRedirectUrl from '../../utils/get-redirect-url';
 
-const {PREPRINTS: {providers}} = config;
+const {
+    PREPRINTS: {providers},
+    OSF: {renderUrl}
+} = config;
 
 // Error handling for API
 const handlers = new Map([
@@ -198,9 +201,10 @@ export default Ember.Route.extend(Analytics, ResetScrollMixin, SetupSubmitContro
                     ['dc.license', license ? license.get('name') : 'No license']
                 );
 
-                if (/\.pdf$/.test(primaryFile.get('name'))) {
-                    highwirePress.push(['citation_pdf_url', primaryFile.get('links').download]);
-                }
+                highwirePress.push([
+                    'citation_pdf_url',
+                    `${renderUrl}?url=${encodeURIComponent(`${primaryFile.get('links').download}?direct&mode=render`)}`
+                ]);
 
                 const openGraphTags = openGraph
                     .map(([property, content]) => ({


### PR DESCRIPTION
<!-- Before submit your Pull Request, make sure you picked
     the right branch:

     - For hotfixes, select "master" as the target branch
     - For new features, select "develop" as the target branch
     - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch -->

## Ticket

https://openscience.atlassian.net/browse/EOSF- 

## Purpose

Google Scholar needs citation_pdf_url for all the things, but we only supplied it for actual PDFs.

## Changes

This uses the MFR URL from the primary file, *should* render a PDF.

## Side effects

<!--Any possible side effects? -->



