### PR TITLE
[EOSF-608] Add scrollTo on page change of search results

### DIFF
--- a/app/controllers/discover.js
+++ b/app/controllers/discover.js
@@ -383,6 +383,7 @@ export default Ember.Controller.extend(Analytics, {
         setLoadPage(pageNumber) {
             this.set('page', pageNumber);
             this.loadPage();
+            window.scrollTo(0, Ember.$('#searchResults').position().top - Ember.$('.preprint-navbar').height()*2 - 10);
         },
 
         clearFilters() {


### PR DESCRIPTION

## Ticket

https://openscience.atlassian.net/browse/EOSF-608

## Purpose
Prevent inconsistent behavior of window location on change of search result page. As indicated by the ticket, depending on the browser being used, going to another page of search results either moves the window to the middle of the results or stays at the bottom. The wanted behavior is to have the window be relocated to the top of the search results, like our other search pages. 

## Changes
Add a window.scrollTo on the page change action. The value is calculated based on the location of search results, to allow for proper scrolling even when the page is at half size. Alternatives to how the value should be calculated are welcome, as this does not seem to be the most robust way to do it, although it does the trick here consistently and smoothly.


