### PR TITLE
Feature/BITSS and AgriXiv Navbar Link Fixes [EOSF-613]

### DIFF
--- a/app/styles/brands/agrixiv.scss
+++ b/app/styles/brands/agrixiv.scss
@@ -5,7 +5,7 @@
     black,                                  // Color, theme color #2 (text color mostly, usually white or black)
     #85BF9B,                                // Color, theme color #3 (navbar color, preferably a dark color)
     white,                                // Color, theme color #4 (used in link colors)
-    white,                                  // Color, theme color #5 (text color that contrasts with #2, usually black or white)
+    black,                                  // Color, theme color #5 (text color that contrasts with #2, usually black or white)
     $logo-dir + 'agrixiv-banner.svg',        // String, path to the rectangular provider logo
     $logo-dir + 'agrixiv-logo.svg', // String, path to the square provider logo
     false,                                   // Boolean, whether to use the white share logo or not

--- a/app/styles/brands/bitss.scss
+++ b/app/styles/brands/bitss.scss
@@ -5,7 +5,7 @@
     black,
     #1C4063,
     #05233B,
-    black,
+    white,
     $logo-dir + 'bitss-banner.png',
     $logo-dir + 'bitss-logo.png',
     false,


### PR DESCRIPTION

## Ticket

https://openscience.atlassian.net/browse/EOSF-613

## Purpose

When navbar links have focus state for BITSS and AgriXiv preprint providers, the link color is the same as the surrounding background color.

## Changes
Modifies theme-color-5 for agrixiv and bitss.

![screen shot 2017-04-19 at 5 12 47 pm](https://cloud.githubusercontent.com/assets/9755598/25202634/0daac1d6-2524-11e7-849b-b92e6b8a48fe.png)
![screen shot 2017-04-19 at 5 13 25 pm](https://cloud.githubusercontent.com/assets/9755598/25202633/0daa7f50-2524-11e7-80e9-37ec626a1648.png)


## Side effects

<!--Any possible side effects? -->



