### PR TITLE
Feature/Font-Awesome in Safari [EOSF-548]

### DIFF
--- a/app/index.html
+++ b/app/index.html
@@ -21,7 +21,7 @@
             skipStartupTypeset: true
         });
     </script>
-    <link href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.6.3/css/font-awesome.css" rel="stylesheet" type="text/css">
+    <link href="https://maxcdn.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" rel="stylesheet" type="text/css">
   </head>
   <body>
     {{content-for "body"}}

--- a/app/index.html
+++ b/app/index.html
@@ -21,6 +21,7 @@
             skipStartupTypeset: true
         });
     </script>
+    <link href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.6.3/css/font-awesome.css" rel="stylesheet" type="text/css">
   </head>
   <body>
     {{content-for "body"}}


### PR DESCRIPTION
## Ticket

https://openscience.atlassian.net/browse/EOSF-548

## Purpose

When you clear your cache, font awesome fonts aren't loading on first-load in _Safari_. Subsequent loads are fine.

## Changes

Add minified Font-Awesome CDN to head tag of index.html.  There might be better ways to do this, but this seems to ensure that the icons are available on first load.

## Side effects

<!--Any possible side effects? -->



