### PR TITLE
Update PsyArXiv branded footer color [EOSF-620] 

### DIFF
--- a/app/styles/brands/psyarxiv.scss
+++ b/app/styles/brands/psyarxiv.scss
@@ -25,5 +25,5 @@
 
 .branded-footer a,
 #view-page .osf-box-lt .fa {
-    color: #ff383f;
+    color: #CF1D35;
 }


### PR DESCRIPTION
## Ticket

https://openscience.atlassian.net/browse/EOSF-620 

## Purpose
Recently, PsyArXiv changed their colors from #ff383f to #CF1D35.
The buttons and logo colors were changed, but the footer did not get updated to their new color.

## Changes
Update the footer color to #CF1D35 in psyarxiv.scss

### before 
![image](https://cloud.githubusercontent.com/assets/11130339/25351173/db5da9e8-28f5-11e7-8b0a-60d9840db085.png)

### after 
![image](https://cloud.githubusercontent.com/assets/11130339/25351190/e6ec8fd6-28f5-11e7-9ee8-a51a461bea85.png)


## Side effects

<!--Any possible side effects? -->



