### PR TITLE
Handle preprint providers' pages not ready for production [EOSF-619]

### DIFF
--- a/app/routes/provider.js
+++ b/app/routes/provider.js
@@ -22,10 +22,7 @@ export default Ember.Route.extend({
 
         if (providerIds.includes(slugLower)) {
             const {domain} = providers.find(provider => provider.id === slugLower) || {};
-            const isReady = providers.find(function (p) {
-                return p.id === slug;
-            }).ready;
-
+            const isReady = providers.find(provider => provider.id === slug).ready;
             // This should be caught by the proxy, but we'll redirect just in case it is not.
             if (domain) {
                 window.location.replace(

--- a/app/routes/provider.js
+++ b/app/routes/provider.js
@@ -20,8 +20,8 @@ export default Ember.Route.extend({
         const slugLower = (slug || '').toLowerCase();
         this.store
             .findAll('preprint-provider')
-            .then(p => {
-                const providerList = p.filter(function (item){return (item.id !== 'osf');}).map(provider => {
+            .then(results => {
+                const providerList = results.filter(function (result){return (result.id !== 'osf');}).map(provider => {
                     return provider.get('id');
                 });
 

--- a/app/routes/provider.js
+++ b/app/routes/provider.js
@@ -22,6 +22,9 @@ export default Ember.Route.extend({
 
         if (providerIds.includes(slugLower)) {
             const {domain} = providers.find(provider => provider.id === slugLower) || {};
+            const isReady = providers.find(function (p) {
+                return p.id === slug;
+            }).ready;
 
             // This should be caught by the proxy, but we'll redirect just in case it is not.
             if (domain) {
@@ -29,6 +32,10 @@ export default Ember.Route.extend({
                     getRedirectUrl(window.location, domain, slug)
                 );
 
+                return;
+            }
+            if (!isReady) {
+                this.replaceWith('page-not-found');
                 return;
             }
 

--- a/config/environment.js
+++ b/config/environment.js
@@ -46,7 +46,8 @@ module.exports = function(environment) {
                         width: 363,
                         height: 242
                     },
-                    permissionLanguage: 'no_trademark'
+                    permissionLanguage: 'no_trademark',
+                    ready: true
                 },
                 {
                     id: 'engrxiv',
@@ -58,7 +59,8 @@ module.exports = function(environment) {
                         height: 488
 
                     },
-                    permissionLanguage: 'arxiv_non_endorsement'
+                    permissionLanguage: 'arxiv_non_endorsement',
+                    ready: true
                 },
                 {
                     id: 'socarxiv',
@@ -69,7 +71,8 @@ module.exports = function(environment) {
                         width: 1200,
                         height: 488
                     },
-                    permissionLanguage: 'arxiv_trademark_license'
+                    permissionLanguage: 'arxiv_trademark_license',
+                    ready: true
                 },
                 {
                     id: 'psyarxiv',
@@ -80,7 +83,8 @@ module.exports = function(environment) {
                         width: 1200,
                         height: 488
                     },
-                    permissionLanguage: 'arxiv_trademark_license'
+                    permissionLanguage: 'arxiv_trademark_license',
+                    ready: true
                 },
                 {
                     id: 'bitss',
@@ -90,7 +94,8 @@ module.exports = function(environment) {
                         width: 1500,
                         height: 1500
                     },
-                    permissionLanguage: 'no_trademark'
+                    permissionLanguage: 'no_trademark',
+                    ready: true
                 },
                 {
                     id: 'scielo',
@@ -101,7 +106,8 @@ module.exports = function(environment) {
                         width: 1200,
                         height: 488
                     },
-                    permissionLanguage: 'no_trademark'
+                    permissionLanguage: 'no_trademark',
+                    ready: false
                 },
                 {
                     id: 'agrixiv',
@@ -112,7 +118,8 @@ module.exports = function(environment) {
                         width: 1200,
                         height: 488
                     },
-                    permissionLanguage: 'arxiv_non_endorsement'
+                    permissionLanguage: 'arxiv_non_endorsement',
+                    ready: true
                 },
                 {
                     id: 'lawarxiv',
@@ -122,7 +129,8 @@ module.exports = function(environment) {
                         width: 1200,
                         height: 488
                     },
-                    permissionLanguage: 'arxiv_non_endorsement'
+                    permissionLanguage: 'arxiv_non_endorsement',
+                    ready: false
                 }
             ],
         },

--- a/config/environment.js
+++ b/config/environment.js
@@ -90,7 +90,7 @@ module.exports = function(environment) {
                         width: 1500,
                         height: 1500
                     },
-                    permissionLanguage: 'no_trademark',
+                    permissionLanguage: 'no_trademark'
                 },
                 {
                     id: 'scielo',

--- a/config/environment.js
+++ b/config/environment.js
@@ -46,7 +46,7 @@ module.exports = function(environment) {
                         width: 363,
                         height: 242
                     },
-                    permissionLanguage: 'no_trademark',
+                    permissionLanguage: 'no_trademark'
                 },
                 {
                     id: 'engrxiv',
@@ -58,7 +58,7 @@ module.exports = function(environment) {
                         height: 488
 
                     },
-                    permissionLanguage: 'arxiv_non_endorsement',
+                    permissionLanguage: 'arxiv_non_endorsement'
                 },
                 {
                     id: 'socarxiv',
@@ -69,7 +69,7 @@ module.exports = function(environment) {
                         width: 1200,
                         height: 488
                     },
-                    permissionLanguage: 'arxiv_trademark_license',
+                    permissionLanguage: 'arxiv_trademark_license'
                 },
                 {
                     id: 'psyarxiv',
@@ -80,7 +80,7 @@ module.exports = function(environment) {
                         width: 1200,
                         height: 488
                     },
-                    permissionLanguage: 'arxiv_trademark_license',
+                    permissionLanguage: 'arxiv_trademark_license'
                 },
                 {
                     id: 'bitss',
@@ -101,7 +101,7 @@ module.exports = function(environment) {
                         width: 1200,
                         height: 488
                     },
-                    permissionLanguage: 'no_trademark',
+                    permissionLanguage: 'no_trademark'
                 },
                 {
                     id: 'agrixiv',
@@ -112,7 +112,7 @@ module.exports = function(environment) {
                         width: 1200,
                         height: 488
                     },
-                    permissionLanguage: 'arxiv_non_endorsement',
+                    permissionLanguage: 'arxiv_non_endorsement'
                 },
                 {
                     id: 'lawarxiv',
@@ -122,7 +122,7 @@ module.exports = function(environment) {
                         width: 1200,
                         height: 488
                     },
-                    permissionLanguage: 'arxiv_non_endorsement',
+                    permissionLanguage: 'arxiv_non_endorsement'
                 }
             ],
         },

--- a/config/environment.js
+++ b/config/environment.js
@@ -47,7 +47,6 @@ module.exports = function(environment) {
                         height: 242
                     },
                     permissionLanguage: 'no_trademark',
-                    ready: true
                 },
                 {
                     id: 'engrxiv',
@@ -60,7 +59,6 @@ module.exports = function(environment) {
 
                     },
                     permissionLanguage: 'arxiv_non_endorsement',
-                    ready: true
                 },
                 {
                     id: 'socarxiv',
@@ -72,7 +70,6 @@ module.exports = function(environment) {
                         height: 488
                     },
                     permissionLanguage: 'arxiv_trademark_license',
-                    ready: true
                 },
                 {
                     id: 'psyarxiv',
@@ -84,7 +81,6 @@ module.exports = function(environment) {
                         height: 488
                     },
                     permissionLanguage: 'arxiv_trademark_license',
-                    ready: true
                 },
                 {
                     id: 'bitss',
@@ -95,7 +91,6 @@ module.exports = function(environment) {
                         height: 1500
                     },
                     permissionLanguage: 'no_trademark',
-                    ready: true
                 },
                 {
                     id: 'scielo',
@@ -107,7 +102,6 @@ module.exports = function(environment) {
                         height: 488
                     },
                     permissionLanguage: 'no_trademark',
-                    ready: false
                 },
                 {
                     id: 'agrixiv',
@@ -119,7 +113,6 @@ module.exports = function(environment) {
                         height: 488
                     },
                     permissionLanguage: 'arxiv_non_endorsement',
-                    ready: true
                 },
                 {
                     id: 'lawarxiv',
@@ -130,7 +123,6 @@ module.exports = function(environment) {
                         height: 488
                     },
                     permissionLanguage: 'arxiv_non_endorsement',
-                    ready: false
                 }
             ],
         },


### PR DESCRIPTION
## Ticket

https://openscience.atlassian.net/browse/EOSF-619 

## Purpose

Preprint providers pages that are not currently active in Production (or incomplete). Attempting to visit their page should lead to a "Page not found." Instead, it leads to error and a completely blank page.  We have in this case sceilo and lawarxiv.

## Changes
Update the preprints config and add flag "ready" that indicate whether the preprint provider is ready on production or not. Handle the unready providers and display "page not found".

## Side effects

<!--Any possible side effects? -->



