### PR TITLE
[EOSF-636] Provider carousel controls fix

### DIFF
--- a/app/styles/_variables.scss
+++ b/app/styles/_variables.scss
@@ -4,3 +4,4 @@ $preprint-title: #D2D2D2;
 $preprint-title-hover: #D5E6ED;
 $gradient-percentage: 15%;
 $nav-bar-height: 25px;
+$carousel-control-width: 10%;

--- a/app/styles/app.scss
+++ b/app/styles/app.scss
@@ -1,7 +1,8 @@
+/* Import variables before bootstrap so that boostrap variables can be overridden */
+@import 'variables';
 @import 'bootstrap';
 @import 'ember-power-select';
 @import 'base';
-@import 'variables';
 @import 'authors';
 @import 'validated-input';
 @import 'hint';


### PR DESCRIPTION
## Ticket

https://openscience.atlassian.net/browse/EOSF-636

## Purpose

Fix provider carousel controls overlapping provider logos.

## Changes

* Import SASS variables before bootstrap so that bootstrap variables can be overridden
* Override bootstrap carousel control width (set to 10%, was 15%)

## Side effects

This fix is global to preprints so it also fixes the carousel on /preprints/discover



