### PR TITLE
Fix alignment for subject taxonomies [EOSF-285]

### DIFF
--- a/app/components/subject-picker/template.hbs
+++ b/app/components/subject-picker/template.hbs
@@ -1,6 +1,6 @@
 <div class="row">
     {{#each selected as |subject|}}
-        <span class="subject">
+        <span class="subject subject-align">
             {{#each subject as |segment|}}
                 <div class="subject-container"><span class="subject-container-text">{{segment.text}}<button class="cancel-subject fa fa-close" aria-label="{{t 'submit.body.remove_subject_aria'}}" title="Remove" {{action 'deselect' subject}} /></span></div><span class="right-arrow"></span>
             {{/each}}

--- a/app/styles/app.scss
+++ b/app/styles/app.scss
@@ -760,7 +760,6 @@ hr {
 }
 
 .subject {
-    display: inline-block;
     color: white;
     overflow: hidden;
     padding: 0 .5rem;
@@ -777,6 +776,10 @@ hr {
     .right-arrow:last-of-type {
         display: none;
     }
+}
+
+.subject-align {
+    display: inline-block;
 }
 
 .subject-container {


### PR DESCRIPTION
## Purpose

To fix the alignment for the subject taxonomies.

## Changes

The ` inline-block ` style was throwing the subject class off.  Changes include removing that styling from the ` .subject ` class and tweaking styling for other containers that used that property of the ` .subject ` class.

## Before
<img width="1440" alt="screen shot 2017-05-04 at 11 35 37 am" src="https://cloud.githubusercontent.com/assets/19379783/25711826/de540bfe-30bd-11e7-9e36-42c6807dfef9.png">

## After
After changes, the subject taxonomies look like they did before previous changes to the class.
<img width="1440" alt="screen shot 2017-05-04 at 11 33 55 am" src="https://cloud.githubusercontent.com/assets/19379783/25711862/f74e1c6c-30bd-11e7-9a79-d2b8cbe96059.png">

The subject-picker, which used the ` inline-block ` style of the ` .subject ` class, also looks like it was designed to before changes.
<img width="947" alt="screen shot 2017-05-04 at 11 33 08 am" src="https://cloud.githubusercontent.com/assets/19379783/25711933/32569b90-30be-11e7-903c-671f1f176c1e.png">


https://openscience.atlassian.net/browse/EOSF-285