### PR TITLE
Hotfix/Whitelist Preprints.org [EOSF-635]

### DIFF
--- a/app/controllers/discover.js
+++ b/app/controllers/discover.js
@@ -40,7 +40,8 @@ export default Ember.Controller.extend(Analytics, {
         'bioRxiv',
         'Cogprints',
         'PeerJ',
-        'Research Papers in Economics'
+        'Research Papers in Economics',
+        'Preprints.org'
     ].map(item => item.toLowerCase()),
 
     page: 1,


### PR DESCRIPTION
## Ticket

https://openscience.atlassian.net/browse/EOSF-635

## Purpose

Now that Preprints.org has been fully backharvested, add Preprints.org to the whitelist of available preprint servers.

## Changes

![screen shot 2017-05-04 at 5 22 32 pm](https://cloud.githubusercontent.com/assets/9755598/25725510/55f29dbc-30ee-11e7-9afb-7952df2d027e.png)


## Side effects

<!--Any possible side effects? -->



