### PR TITLE
Feature/Fix Hyperlinks on Search Results [EOSF-644]

### DIFF
--- a/app/templates/components/search-result.hbs
+++ b/app/templates/components/search-result.hbs
@@ -66,7 +66,7 @@
                     {{#if result.hyperLinks}}
                         <ul class="preprints-block-list m-t-sm">
                             {{#each result.hyperLinks as |link|}}
-                                <li><a href='{{link.url}}' {{action 'click' 'link' 'Preprints - Discover - Result Hyperlink' link.url}}>{{link.url}}</a></li>
+                                <li><a href='{{link.url}}' onclick={{action 'click' 'link' 'Preprints - Discover - Result Hyperlink' link.url}}>{{link.url}}</a></li>
                             {{/each}}
                         </ul>
                     {{/if}}


### PR DESCRIPTION
## Ticket

https://openscience.atlassian.net/browse/EOSF-644

## Purpose

Hyperlinks broken on search results.  They don't force open a new tab (or window). User must right-click and open in new tab to see content/page. 

## Changes

Adds onclick to 'a' tag.

## Side effects

<!--Any possible side effects? -->



