### PR TITLE
Feature/Fix Branded Support Links [EOSF-627]

### DIFF
--- a/app/styles/brands/agrixiv.scss
+++ b/app/styles/brands/agrixiv.scss
@@ -4,8 +4,8 @@
     #E7F7E1,                                // Color, theme color #1 (header backgrounds, hover backgrounds)
     black,                                  // Color, theme color #2 (text color mostly, usually white or black)
     #85BF9B,                                // Color, theme color #3 (navbar color, preferably a dark color)
-    white,                                // Color, theme color #4 (used in link colors)
-    black,                                  // Color, theme color #5 (text color that contrasts with #2, usually black or white)
+    #3e7553,                                // Color, theme color #4 (used in link colors)
+    white,                                  // Color, theme color #5 (text color that contrasts with #2, usually black or white)
     $logo-dir + 'agrixiv-banner.svg',        // String, path to the rectangular provider logo
     $logo-dir + 'agrixiv-logo.svg', // String, path to the square provider logo
     false,                                   // Boolean, whether to use the white share logo or not

--- a/app/styles/brands/psyarxiv.scss
+++ b/app/styles/brands/psyarxiv.scss
@@ -4,7 +4,7 @@
     #062F4F,
     white,
     #216C79,
-    #afcee9,
+    #C7DADD,
     black,
     $logo-dir + 'psyarxiv-color-small.png',
     $logo-dir + 'psyarxiv-square-color-small.png',

--- a/app/styles/brands/psyarxiv.scss
+++ b/app/styles/brands/psyarxiv.scss
@@ -4,7 +4,7 @@
     #062F4F,
     white,
     #216C79,
-    #C7DADD,
+    #7EA9B1,
     black,
     $logo-dir + 'psyarxiv-color-small.png',
     $logo-dir + 'psyarxiv-square-color-small.png',

--- a/app/styles/brands/psyarxiv.scss
+++ b/app/styles/brands/psyarxiv.scss
@@ -4,13 +4,13 @@
     #062F4F,
     white,
     #216C79,
-    white,
+    #afcee9,
     black,
     $logo-dir + 'psyarxiv-color-small.png',
     $logo-dir + 'psyarxiv-square-color-small.png',
     true,
-    true,
-    false
+    false,
+    true
 );
 
 .preprint-submit-button {


### PR DESCRIPTION
## Ticket

https://openscience.atlassian.net/browse/EOSF-627

## Purpose

Improve visibility of support links for agrixiv and psyarxiv.

## Changes
Agrixiv - 
theme-color-4 was changed to a darker green (#3e7553). This makes the support link on the not-found page dark green, as well as changes the focus background color of the navbar links to dark green. Theme-color-5 was then changed to white, which is the navbar link text color when active. On support-link hover the color does not change, but an underline is added. 
![screen shot 2017-05-08 at 1 55 12 pm](https://cloud.githubusercontent.com/assets/9755598/25817733/327f2d2c-33f6-11e7-9c5f-90430175fde0.png)
![screen shot 2017-05-08 at 1 55 20 pm](https://cloud.githubusercontent.com/assets/9755598/25817732/327cd0ae-33f6-11e7-9321-0790aa33be08.png)
![screen shot 2017-05-08 at 2 14 18 pm](https://cloud.githubusercontent.com/assets/9755598/25818489/c04fb8ae-33f8-11e7-9037-ff2afee27692.png)



Psyarxiv - 
Changed theme-color-4 to a light teal (#7EA9B1). $use-theme-color-logo was changed to false, and $use-contrast-link-color was changed to true.  This makes the support link and the active background color of the navbar links this light teal color.   On support-link hover the color does not change, but an underline is added.
![screen shot 2017-05-08 at 2 12 14 pm](https://cloud.githubusercontent.com/assets/9755598/25818397/7d2b4052-33f8-11e7-9436-d768fc70dd19.png)
![screen shot 2017-05-08 at 2 12 20 pm](https://cloud.githubusercontent.com/assets/9755598/25818400/7e915e72-33f8-11e7-85f6-41fb7654e756.png)
![screen shot 2017-05-08 at 2 14 23 pm](https://cloud.githubusercontent.com/assets/9755598/25818494/c2137662-33f8-11e7-921b-566870140de3.png)

<!-- Briefly describe or list your changes  -->

## Side effects

<!--Any possible side effects? -->



