### PR TITLE
[EOSF-656] Remove tooltips from landing page subjects

### DIFF
--- a/app/components/taxonomy-top-list.js
+++ b/app/components/taxonomy-top-list.js
@@ -18,20 +18,6 @@ import Analytics from 'ember-osf/mixins/analytics';
  */
 export default Ember.Component.extend(Analytics, {
     theme: Ember.inject.service(),
-    // jscs:disable disallowQuotedKeysInObjects
-    subjectTooltips: {
-        'Architecture': 'Architectural Engineering, Construction Engineering, Environmental Design, Interior Architecture, Landscape Architecture',
-        'Arts and Humanities': 'Fine Arts, History, Music, Philosophy, Religion',
-        'Business': 'Accounting, Finance and Financial Management, Human Resource Management, Marketing, Taxation',
-        'Education': 'Curriculum and Instruction, Educational Administration and Supervision, Educational Leadership, Higher Education, Liberal Studies',
-        'Engineering': 'Biomedical Engineering and Bioengineering, Chemical Engineering, Civil and Environmental Engineering, Electrical and Computer Engineering, Mechanical Engineering',
-        'Law': 'Civil Law, Criminal Law, Legislation, State and Local Government Law, Supreme Court of the United States',
-        'Life Sciences': 'Agriculture, Genetics and Genomics, Microbiology, Physiology, Zoology',
-        'Medicine and Health Sciences': 'Anatomy, Diseases, Medical Sciences, Public Health, Veterinary Medicine',
-        'Physical Sciences and Mathematics': 'Chemistry, Computer Sciences, Earth Sciences, Physics, Statistics and Probability',
-        'Social and Behavioral Sciences': 'Anthropology, Economics, Political Science, Psychology, Sociology',
-    },
-    // jscs:enable
     sortedList: Ember.computed('list', 'list.content', function() {
         if (!this.get('list')) {
             return;

--- a/app/templates/components/taxonomy-top-list.hbs
+++ b/app/templates/components/taxonomy-top-list.hbs
@@ -1,7 +1,7 @@
 {{#each sortedList as |pair|}}
     <div class="subject row m-b-sm">
         {{#each pair as |subject|}}
-            <div class="col-xs-12 col-sm-6 subject-item {{if (get subjectTooltips subject.text) 'hint--bottom hint--large'}}" aria-label={{get subjectTooltips subject.text}}>
+            <div class="col-xs-12 col-sm-6 subject-item">
                 {{#link-to (route-prefix 'discover') (query-params subject=subject.text) class='btn btn-primary p-sm' invokeAction=(action "click" "link" (concat 'Index - Browse ' subject.text))}}
                     {{subject.text}}
                 {{/link-to}}

--- a/bower.json
+++ b/bower.json
@@ -9,6 +9,7 @@
     "dropzone": "4.3.0",
     "bootstrap-sass": "3.3.6",
     "toastr": "2.1.2",
+    "hint.css": "hint.css needs to be pinned at 2.3.2 due to licensing restrictions on newer versions",
     "hint.css": "2.3.2",
     "jquery.tagsinput": "1.3.6",
     "loaders.css": "0.1.2",


### PR DESCRIPTION
## Ticket
https://openscience.atlassian.net/browse/EOSF-656

## Purpose
Remove tooltips on launch page due to conflicts with custom taxonomies.




