### PR TITLE
[EOSF-657] Fix color of branded subjects on submit subject picker

### DIFF
--- a/app/styles/app.scss
+++ b/app/styles/app.scss
@@ -731,7 +731,6 @@ hr {
         content: '';
         border-top: 1.4rem solid transparent;
         border-bottom: 1.3rem solid transparent;
-        border-left: 1.4rem solid $brand-primary;
         position: absolute;
         margin-left: -1.5rem;
         margin-top: -1.4rem;
@@ -746,15 +745,15 @@ hr {
     margin-bottom: 1rem;
     font-weight: bold;
     &:hover {
-        .subject-container {
-            background-color: lighten($brand-primary, 10%);
-        }
         .right-arrow:before {
             border-left-color: lighten($brand-primary, 10%);
         }
     }
     .right-arrow:last-of-type {
         display: none;
+    }
+    .right-arrow:before {
+        border-left: 1.4rem solid $brand-primary;
     }
 }
 
@@ -763,7 +762,6 @@ hr {
 }
 
 .subject-container {
-    background-color: $brand-primary;
     display: inline-block;
     transition: background-color 0.1s linear;
     margin-left: -10px;
@@ -795,6 +793,22 @@ hr {
 }
 
 #preprint-form-subjects {
+    .subject {
+         background-color: $brand-primary;
+         &:hover {
+             background-color: lighten($brand-primary, 10%);
+             & > b:after {
+                 border-left-color: lighten($brand-primary, 10%);
+             }
+         }
+         & > b {
+             &%pseudo {
+                 border: {
+                     color: transparent transparent transparent $brand-primary;
+                 }
+             }
+         }
+    }
     ul {
         height: 30rem;
         list-style: none;

--- a/app/styles/brands/_brand.scss
+++ b/app/styles/brands/_brand.scss
@@ -108,6 +108,14 @@ $logo-dir: '../img/provider_logos/';
             &:hover > b:after {
                 border-left-color: $theme-color-1;
             }
+            .right-arrow:before {
+                border-left: 1.4rem solid $theme-color-3;
+            }
+            &:hover {
+                .right-arrow:before {
+                    border-left-color: $theme-color-1;
+                }
+            }
         }
     }
 


### PR DESCRIPTION
## Ticket

https://openscience.atlassian.net/browse/EOSF-657

## Purpose
Fix color of branded subjects on submit subject picker

## Changes
Move CSS around so it can be overwritten by brand, add right-arrow element to branded css

#### Before:
<img width="771" alt="screen shot 2017-05-12 at 2 42 23 pm" src="https://cloud.githubusercontent.com/assets/6268982/26012075/49aa3482-3721-11e7-8a62-4b27c1b902b4.png">

#### After:

<img width="769" alt="screen shot 2017-05-12 at 2 42 01 pm" src="https://cloud.githubusercontent.com/assets/6268982/26012079/4dba51ce-3721-11e7-944f-d143e7a77e2d.png">



