### PR TITLE
Feature/Clear Active Filters > Providers [EOSF-558]

### DIFF
--- a/app/controllers/discover.js
+++ b/app/controllers/discover.js
@@ -63,7 +63,7 @@ export default Ember.Controller.extend(Analytics, {
     subject: '',// Subject query param.  Must be passed to component, so can be reflected in URL,
     _clearFilters() {
         this.set('activeFilters', {
-            providers: this.get('theme.isProvider') ? this.get('activeFilters.providers') : [],
+            providers: [],
             subjects: []
         });
         this.set('provider', '');


### PR DESCRIPTION

## Ticket
https://openscience.atlassian.net/browse/EOSF-558

## Purpose

Issue found by QA - 

> when navigating to the Discover page, then to landing page and back via the navbar, it adds a duplicate tag under “Active filters.” 
![image](https://cloud.githubusercontent.com/assets/9755598/26218825/6db6a6a4-3bda-11e7-8971-26404853c686.png)

## Changes
Update the clearFilters method on the discover controller to reset activeFilters > providers to an empty list.  Previously, we were setting to an empty list unless this was a preprint provider, in which case we were retaining the preprint provider under activeFilters.

However, the search-facet-provider component takes care of setting this activeFilter when needed, so it should just be cleared alongside the other activeFilters.

## Side effects

<!--Any possible side effects? -->



