### PR TITLE
Added npm script to use ember-osf at the tip of the develop branch

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
     "test:cover": "COVERAGE=true yarn test",
     "postinstall": "npm rebuild node-sass",
     "update-assets": "git submodule update --remote",
-    "update-assets-hotfix": "git checkout -b hotfix/update-assets && npm run update-assets && git ci public/assets/osf-assets -m 'Updated assets'"
+    "update-assets-hotfix": "git checkout -b hotfix/update-assets && npm run update-assets && git ci public/assets/osf-assets -m 'Updated assets'",
+    "use-ember-osf-develop": "yarn upgrade ember-osf@https://github.com/CenterForOpenScience/ember-osf.git#develop#$(date -u +%FT%TZ)"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Ticket

N/A

## Purpose

The purpose of this script is to update ember-osf to use the latest commit from the develop branch. It can be run with `yarn use-ember-osf-develop`. The git url in package.json will be tagged with a timestamp, which forces re-resolution of develop to the latest commit on subsequent updates and indicates when ember-osf was last updated to the tip of develop. The resolved url in yarn.lock points to the actual commit.

## Changes

Added a script to update ember-osf to use the latest commit from the develop branch.

## Side effects

None



