### PR TITLE
Make providerAssetsURL settable via environment variable

### DIFF
--- a/config/environment.js
+++ b/config/environment.js
@@ -15,7 +15,7 @@ module.exports = function(environment) {
             authorizer: `authorizer:osf-${authorizationType}`,
             authenticator: `authenticator:osf-${authorizationType}`
         },
-        providerAssetsURL: 'https://staging-cdn.osf.io/preprints-assets/',
+        providerAssetsURL: process.env.PROVIDER_ASSETS_URL || 'https://staging-cdn.osf.io/preprints-assets/',
         EmberENV: {
             FEATURES: {
                 // Here you can enable experimental features on an ember canary build


### PR DESCRIPTION
## Ticket

N/A

## Purpose

Make providerAssetsURL settable via environment variable.

## Changes

Changed providerAssetsURL in config/environment.js to be set via PROVIDER_ASSETS_URL environment variable and fall back to staging-cdn if the environment variable is not set.

## Side effects

None.



