### PR TITLE
Updated to use MathJax 2.7.1

### DIFF
--- a/app/index.html
+++ b/app/index.html
@@ -13,7 +13,7 @@
 
     {{content-for "head-footer"}}
     <script type="text/javascript"
-        src="//cdnjs.cloudflare.com/ajax/libs/mathjax/2.6.1/MathJax.js?config=TeX-AMS-MML_HTMLorMML">
+        src="//cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.1/MathJax.js?config=TeX-AMS-MML_HTMLorMML">
     </script>
     <script type="text/x-mathjax-config">
         MathJax.Hub.Config({

--- a/tests/index.html
+++ b/tests/index.html
@@ -17,7 +17,7 @@
     {{content-for "head-footer"}}
     {{content-for "test-head-footer"}}
     <script type="text/javascript"
-        src="//cdnjs.cloudflare.com/ajax/libs/mathjax/2.6.1/MathJax.js?config=TeX-AMS-MML_HTMLorMML">
+        src="//cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.1/MathJax.js?config=TeX-AMS-MML_HTMLorMML">
     </script>
     <script type="text/x-mathjax-config">
         MathJax.Hub.Config({


### PR DESCRIPTION
## Ticket

https://openscience.atlassian.net/browse/EOSF-602

## Purpose

Update to use the latest version of MathJax to ensure there is no dependency on the now defunct MathJax CDN. See: https://github.com/mathjax/MathJax/releases/tag/2.7.1

## Changes

Changed app/index.html to include MathJax 2.7.1 from cdnjs.

## Side effects

Should be none since [MathJax 2.7](http://docs.mathjax.org/en/latest/whats-new-2.7.html) was primarily just a bugfix release with a few opt-in features.



