### PR TITLE
Feature/Restore Subject-Preview Styles [EOSF-675]

### DIFF
--- a/app/styles/app.scss
+++ b/app/styles/app.scss
@@ -283,6 +283,15 @@ $logo-dir: 'img/provider_logos/';
 
 /* VIEW page */
 
+.subject-preview {
+    display: inline-block;
+    background-color: #f8f8f8;
+    border-radius: 3px;
+    border: 1px solid #eee;
+    padding: 1px 7px;
+    margin-bottom: 4px;
+}
+
 .dark-overlay-header-background {
     background: #343333 url("img/dark-overlay.png") top center;
 }


### PR DESCRIPTION
## Ticket 
https://openscience.atlassian.net/browse/EOSF-675

## Purpose

The disciplines on a preprint detail page used to have boxes around them, but now those are gone. 
## Changes
<img width="471" alt="screen shot 2017-06-06 at 10 25 34 pm" src="https://user-images.githubusercontent.com/9755598/26859650-37944ebe-4b07-11e7-82a6-a6bb3a1fa785.png">

Restored subject-preview class definition to stylesheet. Was moved to ember-osf in the discover-page widget PR but was nested under search-results, so was not available to use in this location on the preprints index page.

Screenshots coming - can't authenticate at the moment, so I can't create a preprint locally to view + having docker issues.

## Side effects

<!--Any possible side effects? -->



