### PR TITLE
[EOSF-631] Preprint UI updates for new DOIs

### DIFF
--- a/app/controllers/submit.js
+++ b/app/controllers/submit.js
@@ -12,6 +12,8 @@ import loadAll from 'ember-osf/utils/load-relationship';
 
 import fixSpecialChar from 'ember-osf/utils/fix-special-char';
 
+import extractDoiFromString from 'ember-osf/utils/extract-doi-from-string';
+
 // Enum of available upload states > New project or existing project?
 export const State = Object.freeze(Ember.Object.create({
     START: 'start',
@@ -70,18 +72,6 @@ function disciplineArraysEqual(a, b) {
 function subjectIdMap(subjectArray) {
     // Maps array of arrays of disciplines into array of arrays of discipline ids.
     return subjectArray.map(subjectBlock => subjectBlock.map(subject => subject.id));
-}
-
-function doiRegexExec(doi) {
-    //Strips url out of inputted doi, if any.  For example, user input this DOI: https://dx.doi.org/10.12345/hello. Returns 10.12345/hello.
-    // If doi invalid, returns doi.
-    const doiRegex = /\b(10\.\d{4,}(?:\.\d+)*\/\S+(?:(?!["&\'<>])\S))\b/;
-    if (doi) {
-        const doiOnly = doiRegex.exec(doi);
-        return doiOnly !== null ? doiOnly[0] : doi;
-    }
-    return doi;
-
 }
 
 /**
@@ -288,7 +278,7 @@ export default Ember.Controller.extend(Analytics, BasicsValidations, NodeActions
     doiChanged: Ember.computed('model.doi', 'basicsDOI', function() {
         // Does the pending DOI differ from the saved DOI in the db?
         // If pending DOI and saved DOI are both falsy values, doi has not changed.
-        const basicsDOI = doiRegexExec(this.get('basicsDOI'));
+        const basicsDOI = extractDoiFromString(this.get('basicsDOI'));
         const modelDOI = this.get('model.doi');
         return (basicsDOI || modelDOI) && basicsDOI !== modelDOI;
     }),
@@ -693,7 +683,7 @@ export default Ember.Controller.extend(Analytics, BasicsValidations, NodeActions
                     label: `${this.get('editMode') ? 'Edit' : 'Submit'} - DOI Text Change`
                 });
             let basicsDOI = this.get('basicsDOI');
-            this.set('basicsDOI', doiRegexExec(basicsDOI));
+            this.set('basicsDOI', extractDoiFromString(basicsDOI));
         },
         saveBasics() {
             Ember.get(this, 'metrics')

--- a/app/locales/en/translations.js
+++ b/app/locales/en/translations.js
@@ -50,7 +50,8 @@ export default {
         see_more: 'See more',
         see_less: 'See less',
         version: 'Version',
-        article_doi: `Article DOI`,
+        preprint_doi: `Preprint DOI`,
+        article_doi: `Peer reviewed Publication DOI`,
         citations: `Citations`,
         disciplines: `Disciplines`,
         project_button: {

--- a/app/locales/en/translations.js
+++ b/app/locales/en/translations.js
@@ -51,7 +51,7 @@ export default {
         see_less: 'See less',
         version: 'Version',
         preprint_doi: `Preprint DOI`,
-        article_doi: `Peer reviewed Publication DOI`,
+        article_doi: `Peer-reviewed Publication DOI`,
         citations: `Citations`,
         disciplines: `Disciplines`,
         project_button: {
@@ -162,7 +162,7 @@ export default {
             remove_subject_aria: `Remove subject`,
             basics: {
                 doi: {
-                    label: `Peer reviewed publication DOI (optional)`
+                    label: `Peer-reviewed publication DOI (optional)`
                 },
                 keywords: {
                     label: `Keywords`,

--- a/app/locales/en/translations.js
+++ b/app/locales/en/translations.js
@@ -161,7 +161,7 @@ export default {
             remove_subject_aria: `Remove subject`,
             basics: {
                 doi: {
-                    label: `If published, DOI of associated journal article (optional)`
+                    label: `Peer reviewed publication DOI (optional)`
                 },
                 keywords: {
                     label: `Keywords`,
@@ -180,7 +180,7 @@ export default {
             },
             submit: {
                 paragraph: {
-                    line1: `When you share this preprint, it will become publicly accessible via {{name}} Preprints. You will be unable to delete the preprint file, but you can update or modify it. This also creates an OSF project in case you would like to attach other content to your preprint such as supplementary materials, appendices, data, or protocols. If posting this preprint is your first exposure to the OSF, you will receive an email introducing OSF to you.`,
+                    line1: `When you share this preprint, the DOI will be created and the preprint will become publicly accessible via {{name}} Preprints. You will be unable to delete the preprint file, but you can update or modify it. This also creates an OSF project in case you would like to attach other content to your preprint such as supplementary materials, appendices, data, or protocols. If posting this preprint is your first exposure to the OSF, you will receive an email introducing OSF to you.`,
                     line2: `By clicking Share, you confirm that all Contributors agree with sharing this preprint, and that you have the right to share it.`
                 },
                 invalid: {

--- a/app/templates/content/index.hbs
+++ b/app/templates/content/index.hbs
@@ -85,6 +85,13 @@
                         </button>
                     </div>
 
+                    {{#if model.links.preprint_doi}}
+                        <div class="p-t-xs">
+                            <h4 class="p-v-md f-w-md"><strong>{{t "content.preprint_doi"}}</strong></h4>
+                            <a href={{model.links.preprint_doi}} {{action "click" "link" "Content - Preprint DOI" model.links.preprint_doi}}>{{extract-doi model.links.preprint_doi}}</a>
+                        </div>
+                    {{/if}}
+
                     {{#if model.doi}}
                         <div class="p-t-xs">
                             <h4 class="p-v-md f-w-md"><strong>{{t "content.article_doi"}}</strong></h4>

--- a/app/templates/content/index.hbs
+++ b/app/templates/content/index.hbs
@@ -88,7 +88,7 @@
                     {{#if model.links.preprint_doi}}
                         <div class="p-t-xs">
                             <h4 class="p-v-md f-w-md"><strong>{{t "content.preprint_doi"}}</strong></h4>
-                            <a href={{model.links.preprint_doi}} {{action "click" "link" "Content - Preprint DOI" model.links.preprint_doi}}>{{extract-doi model.links.preprint_doi}}</a>
+                            <a href={{model.links.preprint_doi}} onclick={{action "click" "link" "Content - Preprint DOI" model.links.preprint_doi}}>{{extract-doi model.links.preprint_doi}}</a>
                         </div>
                     {{/if}}
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -268,10 +268,6 @@ ast-types@0.8.12:
   version "0.8.12"
   resolved "https://registry.yarnpkg.com/ast-types/-/ast-types-0.8.12.tgz#a0d90e4351bb887716c83fd637ebf818af4adfcc"
 
-ast-types@0.8.15:
-  version "0.8.15"
-  resolved "https://registry.yarnpkg.com/ast-types/-/ast-types-0.8.15.tgz#8eef0827f04dff0ec8857ba925abe3fea6194e52"
-
 ast-types@0.9.6:
   version "0.9.6"
   resolved "https://registry.yarnpkg.com/ast-types/-/ast-types-0.9.6.tgz#102c9e9e9005d3e7e3829bf0c4fa24ee862ee9b9"
@@ -4151,7 +4147,7 @@ gauge@~2.6.0:
     strip-ansi "^3.0.1"
     wide-align "^1.1.0"
 
-gauge@~2.7.1, gauge@~2.7.3:
+gauge@~2.7.1:
   version "2.7.4"
   resolved "https://registry.yarnpkg.com/gauge/-/gauge-2.7.4.tgz#2c03405c7538c39d7eb37b317022e325fb018bf7"
   dependencies:
@@ -4469,11 +4465,7 @@ homedir-polyfill@^1.0.0:
   dependencies:
     parse-passwd "^1.0.0"
 
-hosted-git-info@^2.1.4, hosted-git-info@^2.1.5:
-  version "2.5.0"
-  resolved "https://registry.yarnpkg.com/hosted-git-info/-/hosted-git-info-2.5.0.tgz#6d60e34b3abbc8313062c3b798ef8d901a07af3c"
-
-hosted-git-info@~2.1.5:
+hosted-git-info@^2.1.4, hosted-git-info@^2.1.5, hosted-git-info@~2.1.5:
   version "2.1.5"
   resolved "https://registry.yarnpkg.com/hosted-git-info/-/hosted-git-info-2.1.5.tgz#0ba81d90da2e25ab34a332e6ec77936e1598118b"
 
@@ -6030,16 +6022,7 @@ npm@3.10.8:
     gauge "~2.6.0"
     set-blocking "~2.0.0"
 
-npmlog@^4.0.0, npmlog@^4.0.2:
-  version "4.1.2"
-  resolved "https://registry.yarnpkg.com/npmlog/-/npmlog-4.1.2.tgz#08a7f2a8bf734604779a9efa4ad5cc717abb954b"
-  dependencies:
-    are-we-there-yet "~1.1.2"
-    console-control-strings "~1.1.0"
-    gauge "~2.7.3"
-    set-blocking "~2.0.0"
-
-npmlog@~4.0.0:
+npmlog@^4.0.0, npmlog@^4.0.2, npmlog@~4.0.0:
   version "4.0.2"
   resolved "https://registry.yarnpkg.com/npmlog/-/npmlog-4.0.2.tgz#d03950e0e78ce1527ba26d2a7592e9348ac3e75f"
   dependencies:
@@ -6696,20 +6679,11 @@ realize-package-specifier@~3.0.3:
     dezalgo "^1.0.1"
     npm-package-arg "^4.1.1"
 
-recast@0.10.33:
+recast@0.10.33, recast@^0.10.10:
   version "0.10.33"
   resolved "https://registry.yarnpkg.com/recast/-/recast-0.10.33.tgz#942808f7aa016f1fa7142c461d7e5704aaa8d697"
   dependencies:
     ast-types "0.8.12"
-    esprima-fb "~15001.1001.0-dev-harmony-fb"
-    private "~0.1.5"
-    source-map "~0.5.0"
-
-recast@^0.10.10:
-  version "0.10.43"
-  resolved "https://registry.yarnpkg.com/recast/-/recast-0.10.43.tgz#b95d50f6d60761a5f6252e15d80678168491ce7f"
-  dependencies:
-    ast-types "0.8.15"
     esprima-fb "~15001.1001.0-dev-harmony-fb"
     private "~0.1.5"
     source-map "~0.5.0"


### PR DESCRIPTION
**Note: This PR depends on https://github.com/CenterForOpenScience/ember-osf/pull/215
Builds will fail until that PR is merged and this PR updated to use latest ember-osf.**

## Ticket

https://openscience.atlassian.net/browse/EOSF-631

## Purpose

Update Preprints front-end for automatically minted Preprint DOIs

## Changes

* updated verbiage to reflect automatic minting of DOIs
* added Preprint DOI to preprint content page

## Side effects

None

## Testing Notes

* The Preprint DOI may not appear immediately after submission because the DOI may still be in the process of being minted. It should appear after a page refresh.
* double-check verbiage changes
* should make sure both user-entered publication DOI and minted DOI are displayed properly and link correctly