### PR TITLE
Feature/ASU Repository [EOSF-680]

### DIFF
--- a/app/components/additional-provider-list.js
+++ b/app/components/additional-provider-list.js
@@ -1,0 +1,37 @@
+import Ember from 'ember';
+import Analytics from 'ember-osf/mixins/analytics';
+/**
+ * @module ember-preprints
+ * @submodule components
+ */
+
+/**
+ * Displays additional SHARE sources for preprints index page
+ *
+ * Sample usage:
+ * ```handlebars
+ * {{additional-provider-list
+ *     additionalProviders=additionalProviders
+ * }}
+ * ```
+ * @class additional-provider-list
+ */
+export default Ember.Component.extend(Analytics, {
+    theme: Ember.inject.service(),
+    sortedList: Ember.computed('additionalProviders', function() {
+        if (!this.get('additionalProviders')) {
+            return;
+        }
+        const sortedList = this.get('additionalProviders').sort();
+        const pairedList = [];
+        for (let i = 0; i < sortedList.get('length'); i += 2) {
+            let pair = [];
+            pair.pushObject(sortedList.objectAt(i));
+            if (sortedList.objectAt(i + 1)) {
+                pair.pushObject(sortedList.objectAt(i + 1));
+            }
+            pairedList.pushObject(pair);
+        }
+        return pairedList;
+    })
+});

--- a/app/components/search-preprints.js
+++ b/app/components/search-preprints.js
@@ -17,6 +17,7 @@ import Ember from 'ember';
  */
 export default Ember.Component.extend({
     metrics: Ember.inject.service(),
+    theme: Ember.inject.service(),
     actions: {
         search() {
             let query = Ember.$.trim(this.$('#searchBox').val());

--- a/app/controllers/discover.js
+++ b/app/controllers/discover.js
@@ -18,18 +18,17 @@ export default Ember.Controller.extend(Analytics, {
     i18n: Ember.inject.service(),
     theme: Ember.inject.service(),
     activeFilters: { providers: [], subjects: [] },
-    additionalProviders: Ember.computed('themeProvider', function() { // Pulls additionalProviders array off of preprint provider
-        return this.get('themeProvider.additionalProviders') || [];
+    additionalProviders: Ember.computed('themeProvider', function() { // Do additional Providers exist?
+        return (this.get('themeProvider.additionalProviders') || []).length > 1;
     }),
     consumingService: 'preprints', // Consuming service - preprints here
     detailRoute: 'content', // Name of detail route for this application
     discoverHeader: Ember.computed('i18n', 'additionalProviders', function() { // Header for preprints discover page
-        return this.get('additionalProviders').length ? this.get('i18n').t('discover.search.heading_repository_search') : this.get('i18n').t('discover.search.heading');
+        return this.get('additionalProviders') ? this.get('i18n').t('discover.search.heading_repository_search') : this.get('i18n').t('discover.search.heading');
     }),
     end: '', // End query param. Must be passed to component, so can be reflected in the URL
     facets: Ember.computed('i18n.locale', 'additionalProviders', function() { // List of facets available for preprints
-        const additionalProviders = this.get('additionalProviders');
-        if (additionalProviders.length) {
+        if (this.get('additionalProviders')) {
             return [
                 { key: 'sources', title: this.get('i18n').t('discover.main.source'), component: 'search-facet-source'},
                 { key: 'date', title: this.get('i18n').t('discover.main.date'), component: 'search-facet-daterange'},
@@ -53,14 +52,9 @@ export default Ember.Controller.extend(Analytics, {
         OSF: 'OSF Preprints',
         'Research Papers in Economics': 'RePEc'
     },
-    lockedParams: Ember.computed('additionalProviders', function() {
-        if (this.get('additionalProviders').length) {
-            return {};
-        } else {
-            return {types: 'preprint'};
-        }
-
-    }), // Parameter names which cannot be changed
+    lockedParams: Ember.computed('additionalProviders', function() { // Query parameters that cannot be changed.
+        return this.get('additionalProviders') ? {} : {types: 'preprint'};
+    }),
     page: 1, // Page query param. Must be passed to component, so can be reflected in URL
     provider: '', // Provider query param. Must be passed to component, so can be reflected in URL
     q: '', // q query param.  Must be passed to component, so can be reflected in URL
@@ -69,8 +63,7 @@ export default Ember.Controller.extend(Analytics, {
         return this.get('i18n').t('discover.search.placeholder');
     }),
     showActiveFilters: Ember.computed('additionalProviders', function() {  // Whether Active Filters should be displayed.
-        const additionalProviders = this.get('additionalProviders');
-        return additionalProviders.length ? false: true;
+        return !this.get('additionalProviders');
     }),
     sortOptions: Ember.computed('i18n.locale', function() { // Sort options for preprints
         const i18n = this.get('i18n');

--- a/app/controllers/discover.js
+++ b/app/controllers/discover.js
@@ -24,7 +24,7 @@ export default Ember.Controller.extend(Analytics, {
     consumingService: 'preprints', // Consuming service - preprints here
     detailRoute: 'content', // Name of detail route for this application
     discoverHeader: Ember.computed('i18n', 'additionalProviders', function() { // Header for preprints discover page
-        return this.get('additionalProviders') ? this.get('i18n').t('discover.search.heading_repository_search') : this.get('i18n').t('discover.search.heading');
+        return this.get('additionalProviders').length ? this.get('i18n').t('discover.search.heading_repository_search') : this.get('i18n').t('discover.search.heading');
     }),
     facets: Ember.computed('i18n.locale', 'additionalProviders', function() { // List of facets available for preprints
         const additionalProviders = this.get('additionalProviders');

--- a/app/controllers/discover.js
+++ b/app/controllers/discover.js
@@ -26,6 +26,7 @@ export default Ember.Controller.extend(Analytics, {
     discoverHeader: Ember.computed('i18n', 'additionalProviders', function() { // Header for preprints discover page
         return this.get('additionalProviders').length ? this.get('i18n').t('discover.search.heading_repository_search') : this.get('i18n').t('discover.search.heading');
     }),
+    end: '', // End query param. Must be passed to component, so can be reflected in the URL
     facets: Ember.computed('i18n.locale', 'additionalProviders', function() { // List of facets available for preprints
         const additionalProviders = this.get('additionalProviders');
         if (additionalProviders.length) {
@@ -63,7 +64,7 @@ export default Ember.Controller.extend(Analytics, {
     page: 1, // Page query param. Must be passed to component, so can be reflected in URL
     provider: '', // Provider query param. Must be passed to component, so can be reflected in URL
     q: '', // q query param.  Must be passed to component, so can be reflected in URL
-    queryParams: ['page', 'q', 'subject', 'provider'], // Pass in the list of queryParams for this component
+    queryParams: ['page', 'q', 'sources', 'tags', 'type', 'start', 'end', 'subject', 'provider'], // Pass in the list of queryParams for this component
     searchPlaceholder: Ember.computed('i18n', function() { // Search bar placeholder
         return this.get('i18n').t('discover.search.placeholder');
     }),
@@ -84,7 +85,10 @@ export default Ember.Controller.extend(Analytics, {
             sortBy: '-date_updated'
         }];
     }),
-    subject: '',// Subject query param.  Must be passed to component, so can be reflected in URL,
+    sources: '', // Sources query param. Must be passed to component, so can be reflected in the URL
+    start: '', // Start query param. Must be passed to component, so can be reflected in the URL
+    subject: '', // Subject query param.  Must be passed to component, so can be reflected in URL
+    tags: '', // Tags query param.  Must be passed to component, so can be reflected in URL
     themeProvider: Ember.computed('model', function() { // Pulls the preprint provider from the already loaded model
         let themeProvider = null;
         this.get('model').forEach(provider => {
@@ -94,6 +98,7 @@ export default Ember.Controller.extend(Analytics, {
         });
         return themeProvider;
     }),
+    type: '', //Type query param. Must be passed to component, so can be reflected in URL
     _clearFilters() {
         this.set('activeFilters', {
             providers: [],

--- a/app/controllers/discover.js
+++ b/app/controllers/discover.js
@@ -17,6 +17,15 @@ import Analytics from 'ember-osf/mixins/analytics';
 export default Ember.Controller.extend(Analytics, {
     i18n: Ember.inject.service(),
     theme: Ember.inject.service(),
+    additionalProviders: Ember.computed('model', function() {
+        let additionalProviders = [];
+        this.get('model').forEach(provider => {
+            if (provider.id === this.get('theme.id')) {
+                additionalProviders = provider.get('additionalProviders');
+            }
+        });
+        return additionalProviders;
+    }),
     activeFilters: { providers: [], subjects: [] },
     consumingService: 'preprints', // Consuming service - preprints here
     detailRoute: 'content', // Name of detail route for this application

--- a/app/controllers/discover.js
+++ b/app/controllers/discover.js
@@ -58,7 +58,14 @@ export default Ember.Controller.extend(Analytics, {
         OSF: 'OSF Preprints',
         'Research Papers in Economics': 'RePEc'
     },
-    lockedParams: {types: 'preprint'}, // Parameter names which cannot be changed
+    lockedParams: Ember.computed('additionalProviders', function() {
+        if (this.get('additionalProviders').length) {
+            return {};
+        } else {
+            return {types: 'preprint'};
+        }
+
+    }), // Parameter names which cannot be changed
     page: 1, // Page query param. Must be passed to component, so can be reflected in URL
     provider: '', // Provider query param. Must be passed to component, so can be reflected in URL
     q: '', // q query param.  Must be passed to component, so can be reflected in URL

--- a/app/controllers/discover.js
+++ b/app/controllers/discover.js
@@ -18,7 +18,8 @@ export default Ember.Controller.extend(Analytics, {
     i18n: Ember.inject.service(),
     theme: Ember.inject.service(),
     activeFilters: { providers: [], subjects: [] },
-    additionalProviders: Ember.computed('themeProvider', function() { // Do additional Providers exist?
+    additionalProviders: Ember.computed('themeProvider', function() { // Do additionalProviders exist?
+        // for now, using this property to alter many pieces of the landing/discover page
         return (this.get('themeProvider.additionalProviders') || []).length > 1;
     }),
     consumingService: 'preprints', // Consuming service - preprints here

--- a/app/controllers/discover.js
+++ b/app/controllers/discover.js
@@ -31,8 +31,8 @@ export default Ember.Controller.extend(Analytics, {
         if (additionalProviders.length) {
             return [
                 { key: 'sources', title: this.get('i18n').t('discover.main.source'), component: 'search-facet-source'},
-                { key: 'date', title: this.get('i18n').t('discover.main.date'), component: 'search-facet-daterange' },
-                { key: 'type', title: this.get('i18n').t('discover.main.type'), component: 'search-facet-worktype', data: this.get('processedTypes')},
+                { key: 'date', title: this.get('i18n').t('discover.main.date'), component: 'search-facet-daterange'},
+                { key: 'type', title: this.get('i18n').t('discover.main.type'), component: 'search-facet-worktype'},
                 { key: 'tags', title: this.get('i18n').t('discover.main.tag'), component: 'search-facet-typeahead'},
             ];
         } else {

--- a/app/controllers/discover.js
+++ b/app/controllers/discover.js
@@ -17,16 +17,10 @@ import Analytics from 'ember-osf/mixins/analytics';
 export default Ember.Controller.extend(Analytics, {
     i18n: Ember.inject.service(),
     theme: Ember.inject.service(),
-    additionalProviders: Ember.computed('model', function() {
-        let additionalProviders = [];
-        this.get('model').forEach(provider => {
-            if (provider.id === this.get('theme.id')) {
-                additionalProviders = provider.get('additionalProviders');
-            }
-        });
-        return additionalProviders;
-    }),
     activeFilters: { providers: [], subjects: [] },
+    additionalProviders: Ember.computed('themeProvider', function() { // Pulls additionalProviders array off of preprint provider
+        return this.get('themeProvider.additionalProviders') || [];
+    }),
     consumingService: 'preprints', // Consuming service - preprints here
     detailRoute: 'content', // Name of detail route for this application
     discoverHeader: Ember.computed('i18n', function() { // Header for preprints discover page
@@ -91,6 +85,15 @@ export default Ember.Controller.extend(Analytics, {
         }];
     }),
     subject: '',// Subject query param.  Must be passed to component, so can be reflected in URL,
+    themeProvider: Ember.computed('model', function() { // Pulls the preprint provider from the already loaded model
+        let themeProvider = null;
+        this.get('model').forEach(provider => {
+            if (provider.id === this.get('theme.id')) {
+                themeProvider = provider;
+            }
+        });
+        return themeProvider;
+    }),
     _clearFilters() {
         this.set('activeFilters', {
             providers: [],

--- a/app/controllers/discover.js
+++ b/app/controllers/discover.js
@@ -61,8 +61,8 @@ export default Ember.Controller.extend(Analytics, {
     provider: '', // Provider query param. Must be passed to component, so can be reflected in URL
     q: '', // q query param.  Must be passed to component, so can be reflected in URL
     queryParams: ['page', 'q', 'sources', 'tags', 'type', 'start', 'end', 'subject', 'provider'], // Pass in the list of queryParams for this component
-    searchPlaceholder: Ember.computed('i18n', function() { // Search bar placeholder
-        return this.get('i18n').t('discover.search.placeholder');
+    searchPlaceholder: Ember.computed('i18n', 'additionalProviders', function() { // Search bar placeholder
+        return this.get('additionalProviders') ? this.get('i18n').t('discover.search.repository_placeholder'): this.get('i18n').t('discover.search.placeholder');
     }),
     showActiveFilters: Ember.computed('additionalProviders', function() {  // Whether Active Filters should be displayed.
         // additionalProviders are using SHARE facets which do not work with Active Filters at this time

--- a/app/controllers/discover.js
+++ b/app/controllers/discover.js
@@ -24,18 +24,19 @@ export default Ember.Controller.extend(Analytics, {
     consumingService: 'preprints', // Consuming service - preprints here
     detailRoute: 'content', // Name of detail route for this application
     discoverHeader: Ember.computed('i18n', 'additionalProviders', function() { // Header for preprints discover page
+        // If additionalProviders, use more generic Repository Search
         return this.get('additionalProviders') ? this.get('i18n').t('discover.search.heading_repository_search') : this.get('i18n').t('discover.search.heading');
     }),
     end: '', // End query param. Must be passed to component, so can be reflected in the URL
     facets: Ember.computed('i18n.locale', 'additionalProviders', function() { // List of facets available for preprints
-        if (this.get('additionalProviders')) {
+        if (this.get('additionalProviders')) { // if additionalProviders exist, use subset of SHARE facets
             return [
                 { key: 'sources', title: this.get('i18n').t('discover.main.source'), component: 'search-facet-source'},
                 { key: 'date', title: this.get('i18n').t('discover.main.date'), component: 'search-facet-daterange'},
                 { key: 'type', title: this.get('i18n').t('discover.main.type'), component: 'search-facet-worktype'},
                 { key: 'tags', title: this.get('i18n').t('discover.main.tag'), component: 'search-facet-typeahead'},
             ];
-        } else {
+        } else { // Regular preprints and branded preprints get provider and taxonomy facets
             return [
                 { key: 'sources', title: `${this.get('i18n').t('discover.main.providers')}`, component: 'search-facet-provider' },
                 { key: 'subjects', title: `${this.get('i18n').t('discover.main.subject')}`, component: 'search-facet-taxonomy' }
@@ -53,6 +54,7 @@ export default Ember.Controller.extend(Analytics, {
         'Research Papers in Economics': 'RePEc'
     },
     lockedParams: Ember.computed('additionalProviders', function() { // Query parameters that cannot be changed.
+        // if additionalProviders, open up search results to all types of results. Otherwise, restrict to just preprints.
         return this.get('additionalProviders') ? {} : {types: 'preprint'};
     }),
     page: 1, // Page query param. Must be passed to component, so can be reflected in URL
@@ -63,6 +65,7 @@ export default Ember.Controller.extend(Analytics, {
         return this.get('i18n').t('discover.search.placeholder');
     }),
     showActiveFilters: Ember.computed('additionalProviders', function() {  // Whether Active Filters should be displayed.
+        // additionalProviders are using SHARE facets which do not work with Active Filters at this time
         return !this.get('additionalProviders');
     }),
     sortOptions: Ember.computed('i18n.locale', function() { // Sort options for preprints

--- a/app/controllers/discover.js
+++ b/app/controllers/discover.js
@@ -23,8 +23,8 @@ export default Ember.Controller.extend(Analytics, {
     }),
     consumingService: 'preprints', // Consuming service - preprints here
     detailRoute: 'content', // Name of detail route for this application
-    discoverHeader: Ember.computed('i18n', function() { // Header for preprints discover page
-        return this.get('i18n').t('discover.search.heading');
+    discoverHeader: Ember.computed('i18n', 'additionalProviders', function() { // Header for preprints discover page
+        return this.get('additionalProviders') ? this.get('i18n').t('discover.search.heading_repository_search') : this.get('i18n').t('discover.search.heading');
     }),
     facets: Ember.computed('i18n.locale', 'additionalProviders', function() { // List of facets available for preprints
         const additionalProviders = this.get('additionalProviders');

--- a/app/controllers/discover.js
+++ b/app/controllers/discover.js
@@ -24,7 +24,7 @@ export default Ember.Controller.extend(Analytics, {
     consumingService: 'preprints', // Consuming service - preprints here
     detailRoute: 'content', // Name of detail route for this application
     discoverHeader: Ember.computed('i18n', 'additionalProviders', function() { // Header for preprints discover page
-        // If additionalProviders, use more generic Repository Search
+        // If additionalProviders, use more generic Repository Search page title
         return this.get('additionalProviders') ? this.get('i18n').t('discover.search.heading_repository_search') : this.get('i18n').t('discover.search.heading');
     }),
     end: '', // End query param. Must be passed to component, so can be reflected in the URL
@@ -54,7 +54,7 @@ export default Ember.Controller.extend(Analytics, {
         'Research Papers in Economics': 'RePEc'
     },
     lockedParams: Ember.computed('additionalProviders', function() { // Query parameters that cannot be changed.
-        // if additionalProviders, open up search results to all types of results. Otherwise, restrict to just preprints.
+        // if additionalProviders, open up search results to all types of results instead of just preprints.
         return this.get('additionalProviders') ? {} : {types: 'preprint'};
     }),
     page: 1, // Page query param. Must be passed to component, so can be reflected in URL

--- a/app/controllers/discover.js
+++ b/app/controllers/discover.js
@@ -32,10 +32,21 @@ export default Ember.Controller.extend(Analytics, {
     discoverHeader: Ember.computed('i18n', function() { // Header for preprints discover page
         return this.get('i18n').t('discover.search.heading');
     }),
-    facets: Ember.computed('i18n.locale', function() { //List of facets available for preprints
-        return [
-            { key: 'sources', title: `${this.get('i18n').t('discover.main.providers')}`, component: 'search-facet-provider' },
-            { key: 'subjects', title: `${this.get('i18n').t('discover.main.subject')}`, component: 'search-facet-taxonomy' }]
+    facets: Ember.computed('i18n.locale', 'additionalProviders', function() { // List of facets available for preprints
+        const additionalProviders = this.get('additionalProviders');
+        if (additionalProviders.length) {
+            return [
+                { key: 'sources', title: this.get('i18n').t('discover.main.source'), component: 'search-facet-source'},
+                { key: 'date', title: this.get('i18n').t('discover.main.date'), component: 'search-facet-daterange' },
+                { key: 'type', title: this.get('i18n').t('discover.main.type'), component: 'search-facet-worktype', data: this.get('processedTypes')},
+                { key: 'tags', title: this.get('i18n').t('discover.main.tag'), component: 'search-facet-typeahead'},
+            ];
+        } else {
+            return [
+                { key: 'sources', title: `${this.get('i18n').t('discover.main.providers')}`, component: 'search-facet-provider' },
+                { key: 'subjects', title: `${this.get('i18n').t('discover.main.subject')}`, component: 'search-facet-taxonomy' }
+            ]
+        }
     }),
     filterMap: { // Map active filters to facet names expected by SHARE
         providers: 'sources',

--- a/app/controllers/discover.js
+++ b/app/controllers/discover.js
@@ -73,7 +73,10 @@ export default Ember.Controller.extend(Analytics, {
     searchPlaceholder: Ember.computed('i18n', function() { // Search bar placeholder
         return this.get('i18n').t('discover.search.placeholder');
     }),
-    showActiveFilters: true, // Whether Active Filters should be displayed.
+    showActiveFilters: Ember.computed('additionalProviders', function() {  // Whether Active Filters should be displayed.
+        const additionalProviders = this.get('additionalProviders');
+        return additionalProviders.length ? false: true;
+    }),
     sortOptions: Ember.computed('i18n.locale', function() { // Sort options for preprints
         const i18n = this.get('i18n');
         return [{

--- a/app/locales/en/translations.js
+++ b/app/locales/en/translations.js
@@ -68,7 +68,8 @@ export default {
             heading_repository_search: `Repository Search`,
             paragraph: `powered by`,
             partner: `Partner Repositories`,
-            placeholder: `Search preprints...`
+            placeholder: `Search preprints...`,
+            repository_placeholder: `Search repository...`
         },
         sort_by: `Sort by`,
         sort_newest_oldest: `Modified Date (newest to oldest)`,

--- a/app/locales/en/translations.js
+++ b/app/locales/en/translations.js
@@ -110,7 +110,7 @@ export default {
             example: `See an example`
         },
         subjects: {
-            heading: `Browse <small>by subject</small>`
+            heading: `Browse <small>by {{browse-by}}</small>`
         },
         services: {
             top: {

--- a/app/locales/en/translations.js
+++ b/app/locales/en/translations.js
@@ -82,6 +82,10 @@ export default {
             refine: `Refine your search by`,
             providers: `Providers`,
             subject: `Subject`,
+            source: `Source`,
+            date: `Date`,
+            type: `Type`,
+            tag: `Tag`,
             box: {
                 paragraph: `Do you want to add your own research as a preprint?`,
                 button: `Add your preprint`

--- a/app/locales/en/translations.js
+++ b/app/locales/en/translations.js
@@ -65,6 +65,7 @@ export default {
     discover: {
         search: {
             heading: `Preprint Archive Search`,
+            heading_repository_search: `Repository Search`,
             paragraph: `powered by`,
             partner: `Partner Repositories`,
             placeholder: `Search preprints...`

--- a/app/routes/submit.js
+++ b/app/routes/submit.js
@@ -24,6 +24,13 @@ export default Ember.Route.extend(Analytics, ResetScrollMixin, CasAuthenticatedR
             subjects: []
         });
     },
+    afterModel() {
+        return this.get('theme.provider').then(provider => {
+            if (!provider.get('allowSubmissions')) {
+                this.transitionTo('page-not-found');
+            }
+        })
+    },
     setupController(controller, model) {
         this.setupSubmitController(controller, model);
         return this._super(...arguments);

--- a/app/routes/submit.js
+++ b/app/routes/submit.js
@@ -27,7 +27,7 @@ export default Ember.Route.extend(Analytics, ResetScrollMixin, CasAuthenticatedR
     afterModel() {
         return this.get('theme.provider').then(provider => {
             if (!provider.get('allowSubmissions')) {
-                this.transitionTo('page-not-found');
+                this.replaceWith('page-not-found');
             }
         })
     },

--- a/app/styles/app.scss
+++ b/app/styles/app.scss
@@ -6,6 +6,7 @@
 @import 'authors';
 @import 'validated-input';
 @import 'hint';
+@import 'daterangepicker.scss';
 
 /* Override styles from ember-osf and osf */
 .footer {

--- a/app/templates/components/additional-provider-list.hbs
+++ b/app/templates/components/additional-provider-list.hbs
@@ -1,0 +1,11 @@
+{{#each sortedList as |pair|}}
+    <div class="subject row m-b-sm">
+        {{#each pair as |addProvider|}}
+            <div class="col-xs-12 col-sm-6 subject-item">
+                {{#link-to (route-prefix 'discover') (query-params source=addProvider) class='btn btn-primary p-sm' invokeAction=(action "click" "link" (concat 'Index - Browse Additional Providers ' addProvider))}}
+                    {{addProvider}}
+                {{/link-to}}
+            </div>
+        {{/each}}
+    </div>
+{{/each}}

--- a/app/templates/components/additional-provider-list.hbs
+++ b/app/templates/components/additional-provider-list.hbs
@@ -2,7 +2,7 @@
     <div class="subject row m-b-sm">
         {{#each pair as |addProvider|}}
             <div class="col-xs-12 col-sm-6 subject-item">
-                {{#link-to (route-prefix 'discover') (query-params source=addProvider) class='btn btn-primary p-sm' invokeAction=(action "click" "link" (concat 'Index - Browse Additional Providers ' addProvider))}}
+                {{#link-to (route-prefix 'discover') (query-params sources=addProvider) class='btn btn-primary p-sm' invokeAction=(action "click" "link" (concat 'Index - Browse Additional Providers ' addProvider))}}
                     {{addProvider}}
                 {{/link-to}}
             </div>

--- a/app/templates/components/preprint-navbar-branded.hbs
+++ b/app/templates/components/preprint-navbar-branded.hbs
@@ -15,7 +15,9 @@
             {{#if session.isAuthenticated}}
                 <li><a href="{{host}}myprojects/" class="" onbeforeclick={{action "click" "link" "Navbar - My OSF Projects"}}>{{t "components.preprint-navbar-branded.my_projects"}}</a></li>
             {{/if}}
-            <li><a href={{concat theme.pathPrefix 'submit'}} onbeforeclick={{action "click" "link" "Navbar - Add preprint"}}>{{t "global.add_preprint"}}</a></li>
+            {{#if theme.provider.allowSubmissions}}
+                <li><a href={{concat theme.pathPrefix 'submit'}} onbeforeclick={{action "click" "link" "Navbar - Add preprint"}}>{{t "global.add_preprint"}}</a></li>
+            {{/if}}
             <li>{{#link-to (route-prefix 'discover') slug=theme.id class="" invokeAction=(action "click" "link" "Navbar - Search")}}{{t "global.search"}}{{/link-to}}</li>
             {{navbar-auth-dropdown
                 signupUrl=theme.signupUrl

--- a/app/templates/components/search-preprints.hbs
+++ b/app/templates/components/search-preprints.hbs
@@ -1,5 +1,5 @@
 <div class="input-group input-group-lg">
-    <input id="searchBox" type="search" class="form-control" placeholder="{{t "global.search_preprints"}}">
+    <input id="searchBox" type="search" class="form-control" placeholder={{if theme.provider.additionalProviders (t 'discover.search.repository_placeholder')(t "global.search_preprints") }}>
     <span class="input-group-btn">
         <button class="btn btn-default" type="button" {{action "search" this}}>{{t "global.search"}}</button>
     </span>

--- a/app/templates/discover.hbs
+++ b/app/templates/discover.hbs
@@ -18,5 +18,5 @@
     showActiveFilters=showActiveFilters
     sortOptions=sortOptions
     subject=subject
+    themeProvider=themeProvider
 }}
-

--- a/app/templates/discover.hbs
+++ b/app/templates/discover.hbs
@@ -5,6 +5,7 @@
     consumingService=consumingService
     detailRoute=detailRoute
     discoverHeader=discoverHeader
+    end=end
     facets=facets
     fetchedProviders=model
     filterMap=filterMap
@@ -17,6 +18,10 @@
     searchPlaceholder=searchPlaceholder
     showActiveFilters=showActiveFilters
     sortOptions=sortOptions
+    sources=sources
+    start=start
     subject=subject
+    tags=tags
     themeProvider=themeProvider
+    type=type
 }}

--- a/app/templates/index.hbs
+++ b/app/templates/index.hbs
@@ -27,13 +27,15 @@
                     {{total-share-results}}
                 </div>
             </div> {{!END ROW}}
-            <div class="row">
-                <div class="text-center col-xs-12">
-                    <p class="lead">{{t 'index.header.or'}}</p>
-                    <a type="button" class="btn btn-success btn-lg preprint-submit-button" onclick={{action "click" "link" "Index - Add preprint"}} href={{concat theme.pathPrefix 'submit'}}>{{t "global.add_preprint"}}</a>
-                    <div class="m-t-md">{{#link-to (route-prefix 'content') (if theme.provider.example theme.provider.example 'khbvy') invokeAction=(action "click" "link" "Index - See example")}}{{t "index.header.example"}}{{/link-to}}</div>
+            {{#if theme.provider.allowSubmissions}}
+                <div class="row">
+                    <div class="text-center col-xs-12">
+                        <p class="lead">{{t 'index.header.or'}}</p>
+                        <a type="button" class="btn btn-success btn-lg preprint-submit-button" onclick={{action "click" "link" "Index - Add preprint"}} href={{concat theme.pathPrefix 'submit'}}>{{t "global.add_preprint"}}</a>
+                        <div class="m-t-md">{{#link-to (route-prefix 'content') (if theme.provider.example theme.provider.example 'khbvy') invokeAction=(action "click" "link" "Index - See example")}}{{t "index.header.example"}}{{/link-to}}</div>
+                    </div>
                 </div>
-            </div>
+            {{/if}}
         </div> {{!END CONTAINER}}
     </div> {{!END HEADER}}
 

--- a/app/templates/index.hbs
+++ b/app/templates/index.hbs
@@ -44,7 +44,7 @@
         <div class="container"> {{!CONTAINER DIV}}
             <div class="row p-v-md">{{!SUBJECTS ROW}}
                 <div class="col-xs-12">
-                    <h2>{{t "index.subjects.heading"}}</h2>
+                    <h2>{{if theme.provider.additionalProviders (t "index.subjects.heading" browse-by="provider") (t "index.subjects.heading" browse-by="subject")}}</h2>
                     <div class="subjectsList p-lg"> {{!SUBJECTS LIST}}
                         {{#if theme.provider.additionalProviders}}
                             {{additional-provider-list additionalProviders=theme.provider.additionalProviders}}

--- a/app/templates/index.hbs
+++ b/app/templates/index.hbs
@@ -46,7 +46,11 @@
                 <div class="col-xs-12">
                     <h2>{{t "index.subjects.heading"}}</h2>
                     <div class="subjectsList p-lg"> {{!SUBJECTS LIST}}
-                        {{taxonomy-top-list list=model.taxonomies}}
+                        {{#if theme.provider.additionalProviders}}
+                            {{additional-provider-list additionalProviders=theme.provider.additionalProviders}}
+                        {{else}}
+                            {{taxonomy-top-list list=model.taxonomies}}
+                        {{/if}}
                     </div> {{!END SUBJECTS LIST}}
                 </div>
             </div>{{!END ROW}}

--- a/bower.json
+++ b/bower.json
@@ -16,7 +16,10 @@
     "jquery": "^2.2.4",
     "loaders.css": "^0.1.2",
     "jquery-mockjax": "~2.2.1",
-    "Faker": "~3.0.0"
+    "Faker": "~3.0.0",
+    "c3": "0.4.11",
+    "d3": "3.5.17",
+    "bootstrap-daterangepicker": "^2.1.23"
   },
   "resolutions": {
     "jquery": "2.2.4"

--- a/config/environment.js
+++ b/config/environment.js
@@ -99,6 +99,10 @@ module.exports = function(environment) {
                 {
                     id: 'thesiscommons',
                     permissionLanguage: 'no_trademark'
+                },
+                {
+                    id: 'asu',
+                    permissionLanguage: 'no_trademark'
                 }
             ],
         },

--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -173,6 +173,9 @@ module.exports = function(defaults) {
     });
 
     app.import(path.join(app.bowerDirectory, 'jquery.tagsinput/src/jquery.tagsinput.js'));
+    app.import(path.join(app.bowerDirectory, 'bootstrap-daterangepicker/daterangepicker.js'));
+    app.import(path.join(app.bowerDirectory, 'c3/c3.js'));
+    app.import(path.join(app.bowerDirectory, 'd3/d3.js'));
 
     app.import({
         development: path.join(app.bowerDirectory, 'hint.css/hint.css'),

--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -66,7 +66,9 @@ module.exports = function(defaults) {
                 'node_modules/ember-osf/addon/styles',
                 'bower_components/bootstrap-sass/assets/stylesheets',
                 'bower_components/osf-style/sass',
-                'bower_components/hint.css'
+                'bower_components/hint.css',
+                'bower_components/c3',
+                'bower_components/bootstrap-daterangepicker',
             ]
         },
         inlineContent: {

--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
     "ember-link-action": "0.0.35",
     "ember-load-initializers": "0.5.1",
     "ember-metrics": "0.6.3",
-    "ember-osf": "https://github.com/pattisdr/ember-osf.git#2dbbde60d7f5f91501b17e4997a55db5831cedb8",
+    "ember-osf": "https://github.com/CenterForOpenScience/ember-osf.git#5bca63ba333aac4339d4119872e34490bf907fde",
     "ember-page-title": "3.0.6",
     "ember-power-select": "1.0.0-beta.7",
     "ember-read-more": "0.0.13",

--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
     "ember-link-action": "0.0.35",
     "ember-load-initializers": "0.5.1",
     "ember-metrics": "0.6.3",
-    "ember-osf": "0.5.4",
+    "ember-osf": "https://github.com/pattisdr/ember-osf.git#2dbbde60d7f5f91501b17e4997a55db5831cedb8",
     "ember-page-title": "3.0.6",
     "ember-power-select": "1.0.0-beta.7",
     "ember-read-more": "0.0.13",

--- a/tests/integration/components/additional-provider-list-test.js
+++ b/tests/integration/components/additional-provider-list-test.js
@@ -1,25 +1,19 @@
+import Ember from 'ember';
 import { moduleForComponent, test } from 'ember-qunit';
 import hbs from 'htmlbars-inline-precompile';
 
 moduleForComponent('additional-provider-list', 'Integration | Component | additional provider list', {
-  integration: true
+    integration: true
 });
 
-test('it renders', function(assert) {
+test('additionalProviderList renders', function(assert) {
+    this.set('additionalProviders', Ember.A(['B Provider', 'A Provider']));
+    this.render(hbs`{{additional-provider-list additionalProviders=additionalProviders}}`);
 
-  // Set any properties with this.set('myProperty', 'value');
-  // Handle any actions with this.on('myAction', function(val) { ... });
+    // Should be alphabetically sorted as 'A Provider, B Provider'
+    assert.equal(this.$().text().replace(/\s/g, ''), 'AProviderBProvider');
 
-  this.render(hbs`{{additional-provider-list}}`);
+    assert.ok(this.$('.subject-item').length);
+    assert.ok(this.$('.subject-item a').length);
 
-  assert.equal(this.$().text().trim(), '');
-
-  // Template block usage:
-  this.render(hbs`
-    {{#additional-provider-list}}
-      template block text
-    {{/additional-provider-list}}
-  `);
-
-  assert.equal(this.$().text().trim(), 'template block text');
 });

--- a/tests/integration/components/additional-provider-list-test.js
+++ b/tests/integration/components/additional-provider-list-test.js
@@ -1,0 +1,25 @@
+import { moduleForComponent, test } from 'ember-qunit';
+import hbs from 'htmlbars-inline-precompile';
+
+moduleForComponent('additional-provider-list', 'Integration | Component | additional provider list', {
+  integration: true
+});
+
+test('it renders', function(assert) {
+
+  // Set any properties with this.set('myProperty', 'value');
+  // Handle any actions with this.on('myAction', function(val) { ... });
+
+  this.render(hbs`{{additional-provider-list}}`);
+
+  assert.equal(this.$().text().trim(), '');
+
+  // Template block usage:
+  this.render(hbs`
+    {{#additional-provider-list}}
+      template block text
+    {{/additional-provider-list}}
+  `);
+
+  assert.equal(this.$().text().trim(), 'template block text');
+});

--- a/tests/integration/components/search-preprints-test.js
+++ b/tests/integration/components/search-preprints-test.js
@@ -1,8 +1,23 @@
 import { moduleForComponent, test } from 'ember-qunit';
 import hbs from 'htmlbars-inline-precompile';
+import Ember from 'ember';
+
+//Stub location service
+const themeStub = Ember.Service.extend({
+    isProvider: true,
+    provider: Ember.RSVP.resolve({
+        name: 'OSF',
+        additionalProviders: ['Other Provider'],
+
+    })
+});
 
 moduleForComponent('search-preprints', 'Integration | Component | search preprints', {
-  integration: true
+  integration: true,
+  beforeEach: function() {
+      this.register('service:theme', themeStub);
+      this.inject.service('theme');
+  }
 });
 
 test('it renders', function(assert) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2689,9 +2689,9 @@ ember-new-computed@^1.0.2:
   dependencies:
     ember-cli-babel "^5.1.5"
 
-ember-osf@0.5.4:
+"ember-osf@https://github.com/pattisdr/ember-osf.git#2dbbde60d7f5f91501b17e4997a55db5831cedb8":
   version "0.5.4"
-  resolved "https://registry.yarnpkg.com/ember-osf/-/ember-osf-0.5.4.tgz#04a5a188d9c5ec5aaa9cb582b33cb2fbe2d2efb2"
+  resolved "https://github.com/pattisdr/ember-osf.git#2dbbde60d7f5f91501b17e4997a55db5831cedb8"
   dependencies:
     broccoli-funnel "^1.0.1"
     broccoli-merge-trees "^1.1.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2689,9 +2689,9 @@ ember-new-computed@^1.0.2:
   dependencies:
     ember-cli-babel "^5.1.5"
 
-"ember-osf@https://github.com/pattisdr/ember-osf.git#2dbbde60d7f5f91501b17e4997a55db5831cedb8":
+"ember-osf@https://github.com/CenterForOpenScience/ember-osf.git#5bca63ba333aac4339d4119872e34490bf907fde":
   version "0.5.4"
-  resolved "https://github.com/pattisdr/ember-osf.git#2dbbde60d7f5f91501b17e4997a55db5831cedb8"
+  resolved "https://github.com/CenterForOpenScience/ember-osf.git#5bca63ba333aac4339d4119872e34490bf907fde"
   dependencies:
     broccoli-funnel "^1.0.1"
     broccoli-merge-trees "^1.1.1"


### PR DESCRIPTION
## Ticket
https://openscience.atlassian.net/browse/EOSF-680
❗️ depends on https://github.com/CenterForOpenScience/ember-osf/pull/223
❗️ Might need some follow-up changes to the new navbar to conditionally remove the "Add preprint" link on a branded provider.
⭐️ NOTE: additionalProviders array on preprint-provider should have the names of the sources that SHARE is expecting, otherwise we will need some sort of transformation in preprints
⭐️ OSF Provider also needs allowSubmissions populated

## Purpose

Make preprints-side changes to implement ASU repository.  Preprints templates/controllers/routes have been modified themselves to make a collection of multiple types of resources with multiple providers work with the same code as branded preprint-providers.

## Changes
If additionalProviders exist on the preprint-provider:
- Header on Discover Page is "Repository Search" instead of "Preprint Archive Search"
- Use the following SHARE facets: "sources", "date", "type", and "tags" facets instead of  "provider" and "taxonomy" facets
-  Return search results of any type, not just preprints
- Don't show activeFilters (SHARE filters are not designed to work with this at this time)
- Show additionalProviders list instead of top-level taxonomies on index page
- Search placeholder is "Search repository... instead of search preprints..."

If allowSubmissions is False:
- Remove Add preprint link on navbar
- Remove Add preprint button on index page
- Remove Add preprint button on discover page
- Transition to not found if attempting to navigate to submit route directly

Additionally:
- Added c3, d3, bootstrap-daterange picker dependencies so new share-facets could be used
- Increase the list of query params that are permitted for preprints - now "sources", "tags", "type", "start", and "end" are enabled.

## Landing Page
![index](https://user-images.githubusercontent.com/9755598/26946765-68695e32-4c5e-11e7-906f-39afaa31c827.png)

## Discover Page
![asu-discover](https://user-images.githubusercontent.com/9755598/26946938-ed1ad232-4c5e-11e7-87ad-95fdb313585b.png)

## Submit Page
![submit-asu](https://user-images.githubusercontent.com/9755598/26946770-6f44ec12-4c5e-11e7-9b66-bb616b97eed0.png)

## For QA
Most of these changes were made to code for branded preprints.  OSF Preprints and another branded preprint, like psyarxiv's Landing Pages, Discover Pages, and Submit Pages should be checked to make sure all the pieces are there. For submit page - just make sure it loads.
