### PR TITLE
[EOSF-702] Branded preprints domain not getting enough css

### DIFF
--- a/app/templates/application.hbs
+++ b/app/templates/application.hbs
@@ -3,7 +3,11 @@
 {{#if theme.isProvider}}
     {{#if theme.stylesheet}}
         <style>
-            @import url('/preprints/assets/provider_styles.css');
+            {{#if theme.isDomain}}
+                @import url('/assets/provider_styles.css');
+            {{else}}
+                @import url('/preprints/assets/provider_styles.css');
+            {{/if}}
         </style>
         <style>
             @import url('{{theme.stylesheet}}');


### PR DESCRIPTION
<!-- Before submit your Pull Request, make sure you picked
     the right branch:

     - For hotfixes, select "master" as the target branch
     - For new features, select "develop" as the target branch
     - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch -->

## Ticket

https://openscience.atlassian.net/browse/EOSF-702

## Purpose

The url for branded preprints' stylesheets is not correct.  The purpose of this ticket is to change it to point to the right location.

## Side effects

None

## Screenshots

Before changes, branded preprints wasn't being given the right css, so the formatting was using some of the basic preprints css instead:
<img width="983" alt="screen shot 2017-06-09 at 4 03 51 pm" src="https://user-images.githubusercontent.com/19379783/26992576-4918726e-4d2d-11e7-9230-af954bbaae4b.png">

After changes, the branded preprints provider is showing the right styling:
<img width="726" alt="screen shot 2017-06-09 at 4 01 01 pm" src="https://user-images.githubusercontent.com/19379783/26992741-fb2c6afa-4d2d-11e7-9b34-808cd412c3e2.png">