### PR TITLE
Feature/update templates to match provider models [EOSF-695]

### DIFF
--- a/app/sanitizers/advisory-board.js
+++ b/app/sanitizers/advisory-board.js
@@ -1,0 +1,6 @@
+//For bleaching preprint provider attribute advisoryBoard
+export default {
+    elements: ['a', 'b', 'br', 'div', 'em', 'h2', 'li', 'p', 'strong', 'ul', 'i', 'u'],
+    attributes: {
+        __ALL__: ['class', 'href', 'title', 'target']}
+};

--- a/app/sanitizers/description.js
+++ b/app/sanitizers/description.js
@@ -1,0 +1,6 @@
+//For bleaching preprint provider attribute description
+export default {
+    elements: ['a', 'br', 'em', 'p', 'span', 'strong', 'i', 'b', 'u'],
+    attributes: {
+        __ALL__: ['class', 'href', 'title', 'target']}
+};

--- a/app/sanitizers/footer-links.js
+++ b/app/sanitizers/footer-links.js
@@ -1,0 +1,6 @@
+//For bleaching preprint provider attribute footerLinks
+export default {
+    elements: ['a', 'br', 'div', 'em', 'p', 'span', 'strong', 'b', 'i', 'u'],
+    attributes: {
+        __ALL__: ['class', 'style', 'href', 'title', 'target']}
+};

--- a/app/templates/components/preprint-footer-branded.hbs
+++ b/app/templates/components/preprint-footer-branded.hbs
@@ -1,6 +1,6 @@
 <div class="text-center branded-footer-links">
     <div>
-        {{safe-markup model.footerLinks}}
+        {{sanitize-html model.footerLinks "footer-links"}}
     </div>
 
 </div>

--- a/app/templates/components/preprint-footer-branded.hbs
+++ b/app/templates/components/preprint-footer-branded.hbs
@@ -1,51 +1,7 @@
 <div class="text-center branded-footer-links">
     <div>
-        <span>{{model.name}}:</span>
-        <span>
-            <a href="mailto:{{if model.emailSupport model.emailSupport (concat 'support+' model.id '@osf.io')}}"
-               onbeforeclick={{action 'click' 'link' 'Branded Footer - Support'}}
-            >
-                {{t "components.preprint-footer-branded.support"}}
-            </a>
-        </span>
-        <span> | </span>
-        <span>
-            <a href="mailto:{{if model.emailContact model.emailContact (concat 'contact+' model.id '@osf.io')}}"
-               onbeforeclick={{action 'click' 'link' 'Branded Footer - Contact'}}
-            >
-                {{t "components.preprint-footer-branded.contact"}}
-            </a>
-        </span>
-        <span> | </span>
+        {{safe-markup model.footerLinks}}
     </div>
-    <div class="social">
-        {{#if model.socialTwitter}}
-            <a href="https://twitter.com/{{model.socialTwitter}}"
-               aria-label={{t "components.preprint-footer-branded.twitter"}}
-               onbeforeclick={{action 'click' 'link' 'Branded Footer - Twitter'}}
-            >
-                <i class="fa fa-2x fa-twitter"></i>
-            </a>
-        {{/if}}
-        {{#if model.socialFacebook}}
-            <a href="https://www.facebook.com/{{model.socialFacebook}}"
-               aria-label={{t "components.preprint-footer-branded.facebook"}}
-               onbeforeclick={{action 'click' 'link' 'Branded Footer - Facebook'}}
-            >
-                <i class="fa fa-2x fa-facebook"></i>
-            </a>
-        {{/if}}
-        {{#if model.socialInstagram}}
-            <a href="https://instagram.com/{{model.socialInstagram}}"
-               aria-label={{t "components.preprint-footer-branded.instagram"}}
-               onbeforeclick={{action 'click' 'link' 'Branded Footer - Instagram'}}
-            >
-                <i class="fa fa-2x fa-instagram"></i>
-            </a>
-        {{/if}}
-    </div>
-
-
 
 </div>
 

--- a/app/templates/index.hbs
+++ b/app/templates/index.hbs
@@ -12,8 +12,8 @@
                         <div class="provider-brand"></div>
                     {{/if}}
                     <p class="lead">
-                        <span>{{if theme.isProvider theme.provider.description (t "index.header.title.paragraph")}}</span>
                         {{#if theme.isProvider}}
+                            {{safe-markup theme.provider.description}}
                             <br>
                             <small>
                                 <a href="https://osf.io/preprints/" onbeforeclick={{action "click" "link" "Index - Powered By"}}>{{t "index.header.powered_by"}}</a>

--- a/app/templates/index.hbs
+++ b/app/templates/index.hbs
@@ -13,7 +13,7 @@
                     {{/if}}
                     <p class="lead">
                         {{#if theme.isProvider}}
-                            {{safe-markup theme.provider.description}}
+                            {{sanitize-html theme.provider.description "description"}}
                             <br>
                             <small>
                                 <a href="https://osf.io/preprints/" onbeforeclick={{action "click" "link" "Index - Powered By"}}>{{t "index.header.powered_by"}}</a>
@@ -104,7 +104,7 @@
         <div class="container">
             <div class="row">
                 {{#if (and theme.isProvider theme.provider.advisoryBoard.length)}}
-                    {{safe-markup theme.provider.advisoryBoard}}
+                    {{sanitize-html theme.provider.advisoryBoard "advisory-board"}}
                 {{else if (not theme.isProvider)}}
                     <div class="col-xs-12">
                         <h2>{{t "index.advisory.heading"}}</h2>

--- a/bower.json
+++ b/bower.json
@@ -19,7 +19,8 @@
     "Faker": "~3.0.0",
     "c3": "0.4.11",
     "d3": "3.5.17",
-    "bootstrap-daterangepicker": "^2.1.23"
+    "bootstrap-daterangepicker": "^2.1.23",
+    "sanitize.js": "^1.0.0"
   },
   "resolutions": {
     "jquery": "2.2.4"

--- a/package.json
+++ b/package.json
@@ -73,6 +73,7 @@
     "ember-power-select": "1.0.0-beta.7",
     "ember-read-more": "0.0.13",
     "ember-resolver": "2.1.0",
+    "ember-sanitize": "^2.0.2",
     "ember-sortable": "1.8.2",
     "ember-toastr": "1.4.1",
     "ember-truth-helpers": "1.2.0",

--- a/tests/integration/components/preprint-footer-branded-test.js
+++ b/tests/integration/components/preprint-footer-branded-test.js
@@ -5,47 +5,9 @@ moduleForComponent('preprint-footer-branded', 'Integration | Component | preprin
   integration: true
 });
 
-test('shows Twitter', function(assert) {
-    this.set('model', {
-        socialTwitter: 'vincestaples'
-    });
-
-    this.render(hbs`{{preprint-footer-branded model=model}}`);
-
-    assert.equal(this.$('.fa-twitter').length, 1);
-    assert.equal(this.$('.fa-facebook').length, 0);
-    assert.equal(this.$('.fa-instagram').length, 0);
-});
-
-test('shows Facebook', function(assert) {
-    this.set('model', {
-        socialFacebook: 'theWeatherStn'
-    });
-
-    this.render(hbs`{{preprint-footer-branded model=model}}`);
-
-    assert.equal(this.$('.fa-twitter').length, 0);
-    assert.equal(this.$('.fa-facebook').length, 1);
-    assert.equal(this.$('.fa-instagram').length, 0);
-});
-
-test('shows Instagram', function(assert) {
-    this.set('model', {
-        socialInstagram: 'welpherewego'
-    });
-
-    this.render(hbs`{{preprint-footer-branded model=model}}`);
-
-    assert.equal(this.$('.fa-twitter').length, 0);
-    assert.equal(this.$('.fa-facebook').length, 0);
-    assert.equal(this.$('.fa-instagram').length, 1);
-});
-
 test('shows all social', function(assert) {
     this.set('model', {
-        socialTwitter: 'vincestaples',
-        socialFacebook: 'theWeatherStn',
-        socialInstagram: 'welpherewego'
+        footerLinks: '<i class="fa fa-2x fa-twitter"></i><i class="fa fa-2x fa-instagram"></i><i class="fa fa-2x fa-facebook"></i>'
     });
 
     this.render(hbs`{{preprint-footer-branded model=model}}`);
@@ -53,13 +15,4 @@ test('shows all social', function(assert) {
     assert.equal(this.$('.fa-twitter').length, 1);
     assert.equal(this.$('.fa-facebook').length, 1);
     assert.equal(this.$('.fa-instagram').length, 1);
-});
-
-test('uses provider name', function(assert) {
-    const name = 'Social Experiment';
-    this.set('model', { name });
-
-    this.render(hbs`{{preprint-footer-branded model=model}}`);
-
-    assert.ok(this.$(`.branded-footer-links:contains('${name}')`).length);
 });

--- a/tests/integration/components/preprint-footer-branded-test.js
+++ b/tests/integration/components/preprint-footer-branded-test.js
@@ -1,13 +1,22 @@
+import Ember from 'ember';
 import { moduleForComponent, test } from 'ember-qunit';
 import hbs from 'htmlbars-inline-precompile';
+import sanitizer from 'preprint-service/sanitizers/footer-links';
 
 moduleForComponent('preprint-footer-branded', 'Integration | Component | preprint footer branded', {
-  integration: true
+  integration: true,
+
+  setup() {
+    this.container.registry.register('sanitizer:footer-links', Ember.Object.extend(sanitizer));
+  }
+
 });
 
 test('shows all social', function(assert) {
     this.set('model', {
-        footerLinks: '<i class="fa fa-2x fa-twitter"></i><i class="fa fa-2x fa-instagram"></i><i class="fa fa-2x fa-facebook"></i>'
+        footerLinks: `<a class="fa fa-2x fa-twitter"></a>
+                      <a class="fa fa-2x fa-instagram"></a>
+                      <a class="fa fa-2x fa-facebook"></a>`
     });
 
     this.render(hbs`{{preprint-footer-branded model=model}}`);

--- a/tests/unit/helpers/sanitizers-test.js
+++ b/tests/unit/helpers/sanitizers-test.js
@@ -1,0 +1,42 @@
+import { sanitize } from 'ember-sanitize/utils/sanitize';
+import { module, test } from 'ember-qunit';
+import footerSanitizer from 'preprint-service/sanitizers/footer-links';
+import descriptionSanitizer from 'preprint-service/sanitizers/description';
+import advisoryBoardSanitizer from 'preprint-service/sanitizers/advisory-board';
+
+module('SanitizeHelper', {
+});
+
+var html = `<b>Bold</b><strong>Strong</strong><em>emphasis</em>
+            <u>underline</u><a>link</a><ul>unorderedLists</ul><p>paragraph</p>
+            <span>span</span><br><div>div</div><script>noScript</script>`.replace( /\s/g, "");
+
+test('checks footer-links sanitizer', function(assert) {
+  var config = {elements:footerSanitizer.elements, attributes:footerSanitizer.attributes};
+  var result = sanitize(html, config);
+  var expected = `<b>Bold</b><strong>Strong</strong><em>emphasis</em>
+                  <u>underline</u><a>link</a>unorderedLists<p>paragraph</p>
+                  <span>span</span><br><div>div</div>noScript`.replace( /\s/g, "");
+  assert.equal(result, expected);
+
+});
+
+test('checks description sanitizer', function(assert) {
+  var config = {elements:descriptionSanitizer.elements, attributes:descriptionSanitizer.attributes};
+  var result = sanitize(html, config);
+  var expected = `<b>Bold</b><strong>Strong</strong><em>emphasis</em>
+                  <u>underline</u><a>link</a>unorderedLists<p>paragraph</p>
+                  <span>span</span><br>divnoScript`.replace( /\s/g, "");
+  assert.equal(result, expected);
+
+});
+
+test('checks advisory-board sanitizer', function(assert) {
+  var config = {elements:advisoryBoardSanitizer.elements, attributes:advisoryBoardSanitizer.attributes};
+  var result = sanitize(html, config);
+  var expected = `<b>Bold</b><strong>Strong</strong><em>emphasis</em>
+                  <u>underline</u><a>link</a><ul>unorderedLists</ul><p>paragraph</p>
+                  span<br><div>div</div>noScript`.replace( /\s/g, "");
+  assert.equal(result, expected);
+
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -2753,6 +2753,13 @@ ember-runtime-enumerable-includes-polyfill@^1.0.1:
     ember-cli-babel "^5.1.6"
     ember-cli-version-checker "^1.1.6"
 
+ember-sanitize@^2.0.2:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/ember-sanitize/-/ember-sanitize-2.0.2.tgz#23ab899b137e0f7023c2ac362bc659f0103b7cf5"
+  dependencies:
+    ember-cli-babel "^5.1.6"
+    ember-getowner-polyfill "^1.1.0"
+
 ember-simple-auth@1.1.0-beta.5:
   version "1.1.0-beta.5"
   resolved "https://registry.yarnpkg.com/ember-simple-auth/-/ember-simple-auth-1.1.0-beta.5.tgz#f34ac0c9e3887c6a1e5bb121314c736c1126664b"


### PR DESCRIPTION
## Ticket

https://openscience.atlassian.net/browse/EOSF-695

## Purpose

These are the template changes to match Casey's preprint model changes. Properties such as twitter, facebook, and instagram links are removed.

## Changes

Delete references to  email_support, email_contact, social_facebook, social_twitter, and social_instagram in branded_preprint_footer. Instead use footerLinks, description, and advisoryBoard in handlebars templates.

## Side effects

IMPORTANT: The first line of the footers for all current preprint providers will need to be added to the footerLinks field admin app in order for them to show up correctly.
