### PR TITLE
[EOSF-714] Remove footer license language for MindrXiv

### DIFF
--- a/config/environment.js
+++ b/config/environment.js
@@ -89,7 +89,7 @@ module.exports = function(environment) {
                 },
                 {
                     id: 'mindrxiv',
-                    permissionLanguage: 'arxiv_non_endorsement'
+                    permissionLanguage: 'no_trademark'
                 },
                 {
                     id: 'lissa',


### PR DESCRIPTION
## Ticket

https://openscience.atlassian.net/browse/EOSF-714

## Purpose

Remove footer license language for MindrXiv

## Changes

Changed value for mindrxiv permissionLanguage to 'no_trademark'

## Side effects

Footer license language is removed for MindrXiv



