### PR TITLE
[EOSF-713] Update to latest ember-osf commit on develop

### DIFF
--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
     "ember-link-action": "0.0.35",
     "ember-load-initializers": "0.5.1",
     "ember-metrics": "0.6.3",
-    "ember-osf": "https://github.com/CenterForOpenScience/ember-osf.git#fee345f45b99ea29644ce0199d1aa89f89718cf7",
+    "ember-osf": "https://github.com/CenterForOpenScience/ember-osf.git#fc3a8137cd97aa2732b29d42dae1a9be1112994e",
     "ember-page-title": "3.0.6",
     "ember-power-select": "1.0.0-beta.7",
     "ember-read-more": "0.0.13",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3287,9 +3287,9 @@ ember-new-computed@^1.0.2:
   dependencies:
     ember-cli-babel "^5.1.5"
 
-"ember-osf@https://github.com/CenterForOpenScience/ember-osf.git#fee345f45b99ea29644ce0199d1aa89f89718cf7":
+"ember-osf@https://github.com/CenterForOpenScience/ember-osf.git#fc3a8137cd97aa2732b29d42dae1a9be1112994e":
   version "0.5.4"
-  resolved "https://github.com/CenterForOpenScience/ember-osf.git#fee345f45b99ea29644ce0199d1aa89f89718cf7"
+  resolved "https://github.com/CenterForOpenScience/ember-osf.git#fc3a8137cd97aa2732b29d42dae1a9be1112994e"
   dependencies:
     broccoli-funnel "1.2.0"
     broccoli-merge-trees "2.0.0"
@@ -3443,13 +3443,13 @@ ember-toastr@1.4.1:
   dependencies:
     ember-cli-babel "^5.0.0"
 
-ember-truth-helpers@1.2.0:
+ember-truth-helpers@1.2.0, ember-truth-helpers@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/ember-truth-helpers/-/ember-truth-helpers-1.2.0.tgz#e63cffeaa8211882ae61a958816fded3790d065b"
   dependencies:
     ember-cli-babel "^5.1.5"
 
-ember-truth-helpers@1.3.0, ember-truth-helpers@^1.2.0:
+ember-truth-helpers@1.3.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/ember-truth-helpers/-/ember-truth-helpers-1.3.0.tgz#6ed9f83ce9a49f52bb416d55e227426339a64c60"
   dependencies:
@@ -5020,14 +5020,14 @@ js-tokens@^3.0.0:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-3.0.1.tgz#08e9f132484a2c45a30907e9dc4d5567b7f114d7"
 
-js-yaml@3.6.1:
+js-yaml@3.6.1, js-yaml@3.x, js-yaml@^3.2.5, js-yaml@^3.2.7, js-yaml@^3.5.1, js-yaml@^3.6.1:
   version "3.6.1"
   resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.6.1.tgz#6e5fe67d8b205ce4d22fad05b7781e8dadcc4b30"
   dependencies:
     argparse "^1.0.7"
     esprima "^2.6.0"
 
-js-yaml@3.8.4, js-yaml@3.x, js-yaml@^3.2.5, js-yaml@^3.2.7, js-yaml@^3.5.1, js-yaml@^3.6.1:
+js-yaml@3.8.4:
   version "3.8.4"
   resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.8.4.tgz#520b4564f86573ba96662af85a8cafa7b4b5a6f6"
   dependencies:
@@ -7051,7 +7051,7 @@ request-progress@~2.0.1:
   dependencies:
     throttleit "^1.0.0"
 
-request@2, request@2.79.0, request@^2.61.0, request@^2.74.0, request@^2.79.0:
+request@2, request@2.79.0, request@^2.61.0, request@^2.74.0:
   version "2.79.0"
   resolved "https://registry.yarnpkg.com/request/-/request-2.79.0.tgz#4dfe5bf6be8b8cdc37fcf93e04b65577722710de"
   dependencies:
@@ -7076,7 +7076,7 @@ request@2, request@2.79.0, request@^2.61.0, request@^2.74.0, request@^2.79.0:
     tunnel-agent "~0.4.1"
     uuid "^3.0.0"
 
-request@^2.81.0:
+request@^2.79.0, request@^2.81.0:
   version "2.81.0"
   resolved "https://registry.yarnpkg.com/request/-/request-2.81.0.tgz#c6928946a0e06c5f8d6f8a9333469ffda46298a0"
   dependencies:


### PR DESCRIPTION
## Ticket

https://openscience.atlassian.net/browse/EOSF-713

## Purpose

Update to latest ember-osf that includes adding emailSupport back to the preprint provider model

## Changes

Update commit hash for ember-osf in package.json

## Side effects

None



