### PR TITLE
Feature/Create External Providers Property [EOSF-680]

### DIFF
--- a/app/controllers/discover.js
+++ b/app/controllers/discover.js
@@ -29,6 +29,9 @@ export default Ember.Controller.extend(Analytics, {
         return this.get('additionalProviders') ? this.get('i18n').t('discover.search.heading_repository_search') : this.get('i18n').t('discover.search.heading');
     }),
     end: '', // End query param. Must be passed to component, so can be reflected in the URL
+    externalProviders: Ember.computed('model', function() {
+        return this.get('model').filter(item => item.id !== 'osf');
+    }),
     facets: Ember.computed('i18n.locale', 'additionalProviders', function() { // List of facets available for preprints
         if (this.get('additionalProviders')) { // if additionalProviders exist, use subset of SHARE facets
             return [

--- a/app/routes/discover.js
+++ b/app/routes/discover.js
@@ -20,8 +20,7 @@ export default Ember.Route.extend(Analytics, ResetScrollMixin, {
     model() {
         return this
             .get('store')
-            .findAll('preprint-provider', { reload: true })
-            .then(result => result.filter(item => item.id !== 'osf'));
+            .findAll('preprint-provider', { reload: true });
     },
     actions: {
         willTransition() {

--- a/app/templates/discover.hbs
+++ b/app/templates/discover.hbs
@@ -7,7 +7,7 @@
     discoverHeader=discoverHeader
     end=end
     facets=facets
-    fetchedProviders=model
+    fetchedProviders=externalProviders
     filterMap=filterMap
     filterReplace=filterReplace
     lockedParams=lockedParams


### PR DESCRIPTION
https://openscience.atlassian.net/browse/EOSF-680

## Purpose

Add preprint button not showing up on discover page for OSF provider only. Cause: OSF provider resource was not being passed to the discover page component, because that provider was excluded from the model hook.

## Changes

model for discover route => Changed to all providers, instead of providers excluding OSF
externalProviders computed property defined => all providers excluding OSF

externalProviders passed into the discover-page component to populate the provider carousel.  The model is used to get the themeProvider, so the osf provider can be lifted from this and passed to the discover page.  Now the add preprint button will show. 


## Side effects

<!--Any possible side effects? -->



