### PR TITLE
[feature] Edit Advisory Board Allowed Tags [No Ticket]

### DIFF
--- a/app/sanitizers/advisory-board.js
+++ b/app/sanitizers/advisory-board.js
@@ -1,6 +1,6 @@
 //For bleaching preprint provider attribute advisoryBoard
 export default {
-    elements: ['a', 'b', 'br', 'div', 'em', 'h2', 'li', 'p', 'strong', 'ul', 'i', 'u'],
+    elements: ['a', 'b', 'br', 'div', 'em', 'h2', 'h3', 'li', 'p', 'strong', 'ul', 'i', 'u'],
     attributes: {
         __ALL__: ['class', 'href', 'title', 'target']}
 };


### PR DESCRIPTION
Relates to OSF PR [#7381](https://github.com/CenterForOpenScience/osf.io/pull/7381)

#### Ticket
- No ticket.

#### Purpose
- Agrixiv uses `h3` tags in their advisory board on production, so we should probably allow that. 

#### Changes
- Edit allowed tags in advisory-board.js



