### PR TITLE
[feature] Allow style attribute in advisory_board and description [OSF-8206]

### DIFF
--- a/app/sanitizers/advisory-board.js
+++ b/app/sanitizers/advisory-board.js
@@ -2,5 +2,5 @@
 export default {
     elements: ['a', 'b', 'br', 'div', 'em', 'h2', 'li', 'p', 'strong', 'ul', 'i', 'u'],
     attributes: {
-        __ALL__: ['class', 'href', 'title', 'target']}
+        __ALL__: ['class', 'style', 'href', 'title', 'target']}
 };

--- a/app/sanitizers/description.js
+++ b/app/sanitizers/description.js
@@ -2,5 +2,5 @@
 export default {
     elements: ['a', 'br', 'em', 'p', 'span', 'strong', 'i', 'b', 'u'],
     attributes: {
-        __ALL__: ['class', 'href', 'title', 'target']}
+        __ALL__: ['class', 'style', 'href', 'title', 'target']}
 };


### PR DESCRIPTION
#### Companion PR
- https://github.com/CenterForOpenScience/osf.io/pull/7392

#### Ticket
- https://openscience.atlassian.net/browse/OSF-8206

#### Purpose
- Allows (minimal) styling of preprint providers advisory_board and description fields.

#### Changes
- Adds `style` to allowed attributes.

#### Side effects
- None expected.



