### PR TITLE
Feature/Use shareSource for facets [EOSF-649]

### DIFF
--- a/app/components/search-facet-provider.js
+++ b/app/components/search-facet-provider.js
@@ -42,7 +42,7 @@ export default Ember.Component.extend(Analytics, {
                     const providerNames = providers.filter(
                         provider => provider.get('id') !== 'asu'
                     ).map(provider => {
-                        const name = provider.get('name');
+                        const name = provider.get('shareSource') || provider.get('name');
                         // TODO Change this in populate_preprint_providers script to just OSF
                         return name === 'Open Science Framework' ? 'OSF' : name;
                     });
@@ -87,7 +87,7 @@ export default Ember.Component.extend(Analytics, {
                     .sort((a, b) => a.key.toLowerCase() < b.key.toLowerCase() ? -1 : 1)
                     .unshift(
                         ...providers.splice(
-                            providers.findIndex(item => item.key === 'OSF'),
+                            providers.findIndex(item => (/^osf/i).test(item.key)),
                             1
                         )
                     );

--- a/app/components/search-facet-provider.js
+++ b/app/components/search-facet-provider.js
@@ -29,7 +29,7 @@ export default Ember.Component.extend(Analytics, {
     theme: Ember.inject.service(),
     otherProviders: [],
     searchUrl: config.OSF.shareSearchUrl,
-    whiteListedProviders: config.whiteListedProviders,
+    whiteListedProviders: config.whiteListedProviders.map(item => item.toLowerCase()),
     osfUrl: config.OSF.url,
 
     init() {

--- a/app/controllers/discover.js
+++ b/app/controllers/discover.js
@@ -51,6 +51,7 @@ export default Ember.Controller.extend(Analytics, {
         providers: 'sources',
         subjects: 'subjects'
     },
+    //TODO: Add a conversion from shareSource to provider names here if desired
     filterReplace: { // Map filter names for front-end display
         'Open Science Framework': 'OSF',
         'Cognitive Sciences ePrint Archive': 'Cogprints',

--- a/app/controllers/discover.js
+++ b/app/controllers/discover.js
@@ -1,4 +1,5 @@
 import Ember from 'ember';
+import config from 'ember-get-config';
 import Analytics from 'ember-osf/mixins/analytics';
 
 /**
@@ -100,6 +101,7 @@ export default Ember.Controller.extend(Analytics, {
         return themeProvider;
     }),
     type: '', //Type query param. Must be passed to component, so can be reflected in URL
+    whiteListedProviders: config.whiteListedProviders,
     _clearFilters() {
         this.set('activeFilters', {
             providers: [],

--- a/app/templates/discover.hbs
+++ b/app/templates/discover.hbs
@@ -24,4 +24,5 @@
     tags=tags
     themeProvider=themeProvider
     type=type
+    whiteListedProviders=whiteListedProviders
 }}

--- a/config/environment.js
+++ b/config/environment.js
@@ -87,7 +87,7 @@ module.exports = function(environment) {
             'PeerJ',
             'Research Papers in Economics',
             'Preprints.org'
-        ].map(item => item.toLowerCase()),
+        ],
     };
 
     if (environment === 'development') {

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   "author": "",
   "license": "Apache-2.0",
   "devDependencies": {
-    "@centerforopenscience/ember-osf": "0.10.2",
+    "@centerforopenscience/ember-osf": "https://github.com/CenterForOpenScience/ember-osf.git#develop#2017-09-12T18:55:09Z",
     "autoprefixer": "6.3.7",
     "broccoli-asset-rev": "2.4.2",
     "coveralls": "2.11.16",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,9 +2,9 @@
 # yarn lockfile v1
 
 
-"@centerforopenscience/ember-osf@0.10.2":
+"@centerforopenscience/ember-osf@https://github.com/CenterForOpenScience/ember-osf.git#develop#2017-09-12T18:55:09Z":
   version "0.10.2"
-  resolved "https://registry.yarnpkg.com/@centerforopenscience/ember-osf/-/ember-osf-0.10.2.tgz#c7ad63216264b054beb2a9e6683bcad8075be06c"
+  resolved "https://github.com/CenterForOpenScience/ember-osf.git#70eac83f63aeef6e2a42cc422e5585dc0bfaf54b"
   dependencies:
     broccoli-funnel "1.2.0"
     broccoli-merge-trees "2.0.0"


### PR DESCRIPTION
## Ticket

https://openscience.atlassian.net/browse/EOSF-649

## Purpose

Allow facets to use the attribute `shareSource` in share queries on discover page.

Update: This ticket also makes changes in order to pass `whiteListedProviders` to the discover page (This aids the ember-osf portion of this issue).

## Changes

Instead of just using the name of each branded preprint as a filter, `shareSource` will now be used if it is populated.

## Side effects
Note: The facets will show up as the `shareSource` instead of the provider names. This can be changed if desired as it is not particularly pretty.

`whiteListedProviders` in config no longer starts with lowercase elements. 




