### PR TITLE
Feature/Remove total-share-results from branded index pages[EOSF-735]

### DIFF
--- a/app/templates/index.hbs
+++ b/app/templates/index.hbs
@@ -24,7 +24,9 @@
                 {{!SEARCH}}
                 <div class="preprint-search col-xs-10 col-xs-offset-1 col-md-8 col-md-offset-2 m-v-lg" >
                     {{search-preprints search="search"}}
-                    {{total-share-results}}
+                    {{#if (not theme.isProvider)}}
+                        {{total-share-results}}
+                    {{/if}}
                 </div>
             </div> {{!END ROW}}
             {{#if theme.provider.allowSubmissions}}


### PR DESCRIPTION
## Ticket
https://openscience.atlassian.net/browse/EOSF-735

## Purpose
So that the total-share-results component is only used on index page for unbranded preprint providers.

## Changes
Add a conditional to stop the component from rendering. 

## Side effects




