### PR TITLE
[EOSF-621] Branded preprints links on 'Page Not Found'

### DIFF
--- a/app/templates/components/error-page.hbs
+++ b/app/templates/components/error-page.hbs
@@ -13,14 +13,10 @@
                     {{supportEmail}}
                 </a>
             </p>
-            {{#link-to
-                (route-prefix 'index')
-                slug=theme.id
-                class="btn btn-primary m-t-md"
-                invokeAction=(action "click" "link" (concat label " - Go to Index"))
-            }}
+            <a class="btn btn-primary m-t-md" href='{{theme.pathPrefix}}'
+                onclick={{action 'click' 'link' (concat label " - Go to Index")}}>
                 {{t 'components.error-page.go_to' brand=(t (if theme.isProvider "global.provider_brand" "global.brand") name=theme.provider.name)}}
-            {{/link-to}}
+            </a>
         </div>
     </div>
 </div>

--- a/app/templates/components/preprint-navbar-branded.hbs
+++ b/app/templates/components/preprint-navbar-branded.hbs
@@ -5,10 +5,11 @@
             <span class="icon-bar"></span>
             <span class="icon-bar"></span>
         </button>
-        {{#link-to (route-prefix 'index') slug=theme.id class="navbar-brand" invokeAction=(action "click" "link" "Navbar - Brand")~}}
+        <a class="navbar-brand" href='{{theme.pathPrefix}}'
+            onclick={{action "click" "link" "Navbar - Brand"}}>
             <span class="navbar-image" style="background-image: url('{{providerAsset theme.id 'square_color_transparent.png'}}')"></span>
             <span class="navbar-title">{{model.name}} {{t "global.preprints"}}</span>
-        {{~/link-to}}
+        </a>
     </div>
     <div id="preprint-navbar-links" class="navbar-collapse collapse navbar-right">
         <ul class="nav navbar-nav branded-nav">
@@ -18,7 +19,7 @@
             {{#if theme.provider.allowSubmissions}}
                 <li><a href={{concat theme.pathPrefix 'submit'}} onbeforeclick={{action "click" "link" "Navbar - Add preprint"}}>{{t "global.add_preprint"}}</a></li>
             {{/if}}
-            <li>{{#link-to (route-prefix 'discover') slug=theme.id class="" invokeAction=(action "click" "link" "Navbar - Search")}}{{t "global.search"}}{{/link-to}}</li>
+            <li><a class="" href='{{theme.pathPrefix}}discover' onclick={{action "click" "link" "Navbar - Search"}}>{{t "global.search"}}</a></li>
             {{navbar-auth-dropdown
                 signupUrl=theme.signupUrl
                 loginAction=(action 'login')


### PR DESCRIPTION
<!-- Before submit your Pull Request, make sure you picked
     the right branch:

     - For hotfixes, select "master" as the target branch
     - For new features, select "develop" as the target branch
     - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch -->

## Ticket

https://openscience.atlassian.net/browse/EOSF-621

## Purpose

On the branded preprints 'Page Not Found' page, some of the links aren't rendering properly and are showing `undefined`.

## Changes

The main changes done for this ticket include changing the `{{ link-to }}`'s into html `<a>` tags.  The code done in this ticket was taken from https://github.com/CenterForOpenScience/ember-preprints/pull/335 and tested to make sure it works.

Previously, the links being shown on the 'Page Not Found' page for branded preprints would show as `undefined`.  

<img width="1440" alt="screen shot 2017-07-10 at 12 07 13 pm" src="https://user-images.githubusercontent.com/19379783/28027801-72bda3de-6568-11e7-986d-d3ed4bc9168e.png">


After the fix, the links show the correct branded preprint in the link, and will take you to the right page when clicking on it.

<img width="1440" alt="screen shot 2017-07-10 at 12 03 33 pm" src="https://user-images.githubusercontent.com/19379783/28027713-1f7ef8ee-6568-11e7-89ca-3afe912ccf38.png">


## Side effects


