### PR TITLE
[EOSF-764] Add preprint mint DOI's in metatags

### DIFF
--- a/app/routes/content/index.js
+++ b/app/routes/content/index.js
@@ -143,11 +143,11 @@ export default Ember.Route.extend(Analytics, ResetScrollMixin, SetupSubmitContro
                     ['dc.title', title],
                     ['dc.abstract', description],
                     ['dc.identifier', canonicalUrl],
-                    ['dc.identifier', mintDoi],
+                    ['dc.identifier', 'doi:' + mintDoi],
                 ];
                 if(peerDoi !== '') {
                     dublinCore.push(
-                        ['dc.relation', peerDoi]
+                        ['dc.relation', 'doi:' + peerDoi]
                     );
                 }
 

--- a/app/routes/content/index.js
+++ b/app/routes/content/index.js
@@ -88,7 +88,7 @@ export default Ember.Route.extend(Analytics, ResetScrollMixin, SetupSubmitContro
                 const description = node.get('description');
                 const mintDoi = extractDoiFromString(preprint.get('links.preprint_doi'));
                 const peerDoi = preprint.get('doi');
-                const doi = peerDoi !== ''? peerDoi: mintDoi;
+                const doi = peerDoi !== '' ? peerDoi : mintDoi;
                 const image = this.get('theme.logoSharing');
                 const imageUrl = `${origin.replace(/^https/, 'http')}${image.path}`;
                 const dateCreated = new Date(preprint.get('dateCreated') || null);
@@ -143,11 +143,11 @@ export default Ember.Route.extend(Analytics, ResetScrollMixin, SetupSubmitContro
                     ['dc.title', title],
                     ['dc.abstract', description],
                     ['dc.identifier', canonicalUrl],
-                    ['dc.identifier', mintDoi], // Should be the minted doi
+                    ['dc.identifier', mintDoi],
                 ];
                 if(peerDoi !== '') {
                     dublinCore.push(
-                        ['dc.relation', peerDoi] // Should be peer doi
+                        ['dc.relation', peerDoi]
                     );
                 }
 

--- a/app/routes/content/index.js
+++ b/app/routes/content/index.js
@@ -5,6 +5,7 @@ import Analytics from 'ember-osf/mixins/analytics';
 import config from 'ember-get-config';
 import loadAll from 'ember-osf/utils/load-relationship';
 import permissions from 'ember-osf/const/permissions';
+import extractDoiFromString from 'ember-osf/utils/extract-doi-from-string';
 
 const {
     OSF: {url: osfUrl}
@@ -85,7 +86,9 @@ export default Ember.Route.extend(Analytics, ResetScrollMixin, SetupSubmitContro
             .then(([provider, node, license]) => {
                 const title = node.get('title');
                 const description = node.get('description');
-                const doi = preprint.get('doi');
+                const mintDoi = extractDoiFromString(preprint.get('links.preprint_doi'));
+                const peerDoi = preprint.get('doi');
+                const doi = peerDoi !== ''? peerDoi: mintDoi;
                 const image = this.get('theme.logoSharing');
                 const imageUrl = `${origin.replace(/^https/, 'http')}${image.path}`;
                 const dateCreated = new Date(preprint.get('dateCreated') || null);
@@ -120,7 +123,7 @@ export default Ember.Route.extend(Analytics, ResetScrollMixin, SetupSubmitContro
                     ['citation_description', description],
                     ['citation_public_url', canonicalUrl],
                     ['citation_publication_date', `${dateCreated.getFullYear()}/${dateCreated.getMonth() + 1}/${dateCreated.getDate()}`],
-                    ['citation_doi', doi]
+                    ['citation_doi', doi],
                 ];
 
                 // TODO map Eprints fields
@@ -136,12 +139,17 @@ export default Ember.Route.extend(Analytics, ResetScrollMixin, SetupSubmitContro
                 const prism = [];
 
                 // Dublin Core
-                const dublinCore = [
+                var dublinCore = [
                     ['dc.title', title],
                     ['dc.abstract', description],
                     ['dc.identifier', canonicalUrl],
-                    ['dc.identifier', doi]
+                    ['dc.identifier', mintDoi], // Should be the minted doi
                 ];
+                if(peerDoi !== '') {
+                    dublinCore.push(
+                        ['dc.relation', peerDoi] // Should be peer doi
+                    );
+                }
 
                 const tags = [
                     ...preprint.get('subjects').map(subjectBlock => subjectBlock.map(subject => subject.text)),


### PR DESCRIPTION
<!-- Before submit your Pull Request, make sure you picked
     the right branch:

     - For hotfixes, select "master" as the target branch
     - For new features, select "develop" as the target branch
     - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch -->

## Ticket

https://openscience.atlassian.net/browse/EOSF-764

## Purpose

To add mint DOI's to the meta tags so that Google Scholar can get access to them.

## Changes

- Added a conditional to check for either the Peer Review DOI's or the mint DOI's for Highwire Press
- Changed Dublin Core DOI to point at mint DOI's
- Added a conditional Dublin Core DOI in the case that there is a Peer Review DOI


In the case that there is a Peer Review DOI, `citation_doi` and `dc.relation` will point to that DOI.
<img width="1205" alt="screen shot 2017-07-13 at 2 14 45 pm" src="https://user-images.githubusercontent.com/19379783/28181266-016ea4ce-67d6-11e7-8b50-199538f39a05.png">

However, if there isn't a Peer Review DOI, then `citation_doi` will point to the mint DOI and `dc.relation` will not exist (since there isn't a peer review DOI)
<img width="1206" alt="screen shot 2017-07-13 at 2 19 24 pm" src="https://user-images.githubusercontent.com/19379783/28181392-7588b728-67d6-11e7-9c10-93dd938f9172.png">



