### PR TITLE
[EOSF 753] update discover page to work with custom taxonomies

### DIFF
--- a/app/components/search-facet-taxonomy.js
+++ b/app/components/search-facet-taxonomy.js
@@ -39,7 +39,8 @@ export default Ember.Component.extend(Analytics, {
                     text: result.get('text'),
                     children: [],
                     showChildren: false,
-                    childCount: result.get('child_count')
+                    childCount: result.get('child_count'),
+                    shareTitle: result.get('shareTitle'),
                 }))
                 .sort((prev, next) => {
                     if (prev.text > next.text) {

--- a/app/templates/components/search-facet-taxonomy.hbs
+++ b/app/templates/components/search-facet-taxonomy.hbs
@@ -6,7 +6,7 @@
                     <i class="taxonomy-caret fa {{if item.showChildren 'fa-caret-down' 'fa-caret-right'}}"></i>
                 </span>
                 <label class="taxonomy-checkbox">
-                    <input type="checkbox" checked="{{if (if-filter item.text activeFilters.subjects) 'checked'}}" onclick={{action updateFilters 'subjects' item}}>
+                    <input type="checkbox" checked="{{if (if-filter (concat item.shareTitle "|" item.text) activeFilters.subjects) 'checked'}}" onclick={{action updateFilters 'subjects' (concat item.shareTitle "|" item.text)}}>
                     {{item.text}}
                 </label>
             </li>
@@ -22,7 +22,7 @@
                                 <span class="taxonomy-right-padding"></span>
                             {{/if}}
                             <label class="taxonomy-checkbox">
-                                <input type="checkbox" checked="{{if (if-filter child.text activeFilters.subjects) 'checked'}}" onclick={{action updateFilters 'subjects' child}}>
+                                <input type="checkbox" checked="{{if (if-filter (concat item.shareTitle "|" item.text "|" child.text) activeFilters.subjects) 'checked'}}" onclick={{action updateFilters 'subjects' (concat item.shareTitle "|" item.text "|" child.text)}}>
                                 {{child.text}}
                             </label>
                         </li>
@@ -31,7 +31,7 @@
                                 {{#each child.children as |grandkid|}}
                                     <li>
                                         <label class="taxonomy-checkbox">
-                                            <input type="checkbox" checked="{{if (if-filter grandkid.text activeFilters.subjects) 'checked'}}" onclick={{action updateFilters 'subjects' grandkid}}>
+                                            <input type="checkbox" checked="{{if (if-filter (concat item.shareTitle "|" item.text "|" child.text "|" grandkid.text) activeFilters.subjects) 'checked'}}" onclick={{action updateFilters 'subjects' (concat item.shareTitle "|" item.text "|" child.text "|" grandkid.text)}}>
                                             {{grandkid.text}}
                                         </label>
                                     </li>

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   "author": "",
   "license": "Apache-2.0",
   "devDependencies": {
-    "@centerforopenscience/ember-osf": "https://github.com/CenterForOpenScience/ember-osf.git#develop#2017-07-20T01:42:12Z",
+    "@centerforopenscience/ember-osf": "https://github.com/CenterForOpenScience/ember-osf.git#develop#2017-07-21T20:03:47Z",
     "autoprefixer": "6.3.7",
     "broccoli-asset-rev": "2.4.2",
     "coveralls": "2.11.16",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,9 +2,9 @@
 # yarn lockfile v1
 
 
-"@centerforopenscience/ember-osf@https://github.com/CenterForOpenScience/ember-osf.git#develop#2017-07-20T01:42:12Z":
+"@centerforopenscience/ember-osf@https://github.com/CenterForOpenScience/ember-osf.git#develop#2017-07-21T20:03:47Z":
   version "0.7.1"
-  resolved "https://github.com/CenterForOpenScience/ember-osf.git#a3abdf4094ba2cb0f82f9f8ffff6ccadba12afa5"
+  resolved "https://github.com/CenterForOpenScience/ember-osf.git#7471b8889b393fe0a8d064dc3277e793eff6ce5e"
   dependencies:
     broccoli-funnel "1.2.0"
     broccoli-merge-trees "2.0.0"


### PR DESCRIPTION
## Ticket

https://openscience.atlassian.net/browse/EOSF-753

## Purpose

Update discover page to work with custom taxonomies

## Changes

* Use latest ember-osf to get shareTitle in taxonomy model (see https://github.com/CenterForOpenScience/ember-osf/pull/241)
* Use full SHARE taxonomy strings for subjects filter

## Testing Notes

Make sure selecting one or more subject filters works properly.