### PR TITLE
[EOSF-788] Prepend subjects with shareTitle for hilighted taxonomies links

### DIFF
--- a/app/templates/components/taxonomy-top-list.hbs
+++ b/app/templates/components/taxonomy-top-list.hbs
@@ -2,7 +2,7 @@
     <div class="subject row m-b-sm">
         {{#each pair as |subject|}}
             <div class="col-xs-12 col-sm-6 subject-item">
-                {{#link-to (route-prefix 'discover') (query-params subject=subject.text) class='btn btn-primary p-sm' invokeAction=(action "click" "link" (concat 'Index - Browse ' subject.text))}}
+                {{#link-to (route-prefix 'discover') (query-params subject=(concat subject.shareTitle '|' subject.text)) class='btn btn-primary p-sm' invokeAction=(action "click" "link" (concat 'Index - Browse ' subject.text))}}
                     {{subject.text}}
                 {{/link-to}}
             </div>


### PR DESCRIPTION
## Ticket

https://openscience.atlassian.net/browse/EOSF-788

## Purpose

Update links for subjects on landing page to work for custom taxonomies.

## Changes

Prepend subjects with shareTitle

## Testing notes

Make sure this works properly for unbranded and branded preprints