### PR TITLE
[EOSF-766] Fix provider filter on branded preprints

### DIFF
--- a/app/components/search-facet-provider.js
+++ b/app/components/search-facet-provider.js
@@ -94,7 +94,7 @@ export default Ember.Component.extend(Analytics, {
                     this.set('otherProviders', providers);
                 } else {
                     const filtered = providers.filter(
-                        item => item.key.toLowerCase().replace(/\s/g,'') === this.get('theme.id').toLowerCase()
+                        item => item.key === this.get('theme.provider.name')
                     );
 
                     this.set('otherProviders', filtered);


### PR DESCRIPTION
<!-- Before submit your Pull Request, make sure you picked
     the right branch:

     - For hotfixes, select "master" as the target branch
     - For new features, select "develop" as the target branch
     - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch -->

## Ticket

https://openscience.atlassian.net/browse/EOSF-766

## Purpose

To fix the provider filter for branded preprints.

## Changes

The provider filter is determined by comparing the id to the title of the provider.  This does not work with some providers (ex. lissa != LIS Scholarship Archive).  The change in this fix is to compare the title given by SHARE to the title of the provider.  

## Screenshots

<img width="1353" alt="screen shot 2017-08-01 at 10 56 42 am" src="https://user-images.githubusercontent.com/19379783/28831649-280b0b5a-76a8-11e7-806e-3e3edaa34a05.png">
