### PR TITLE
[EOSF-691] use path for highlighted taxonomies

### DIFF
--- a/app/templates/components/taxonomy-top-list.hbs
+++ b/app/templates/components/taxonomy-top-list.hbs
@@ -2,7 +2,7 @@
     <div class="subject row m-b-sm">
         {{#each pair as |subject|}}
             <div class="col-xs-12 col-sm-6 subject-item">
-                {{#link-to (route-prefix 'discover') (query-params subject=(concat subject.shareTitle '|' subject.text)) class='btn btn-primary p-sm' invokeAction=(action "click" "link" (concat 'Index - Browse ' subject.text))}}
+                {{#link-to (route-prefix 'discover') (query-params subject=subject.path) class='btn btn-primary p-sm' invokeAction=(action "click" "link" (concat 'Index - Browse ' subject.text))}}
                     {{subject.text}}
                 {{/link-to}}
             </div>

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   "author": "",
   "license": "Apache-2.0",
   "devDependencies": {
-    "@centerforopenscience/ember-osf": "https://github.com/CenterForOpenScience/ember-osf.git#develop#2017-08-02T14:36:24Z",
+    "@centerforopenscience/ember-osf": "https://github.com/CenterForOpenScience/ember-osf.git#develop#2017-08-02T22:23:33Z",
     "autoprefixer": "6.3.7",
     "broccoli-asset-rev": "2.4.2",
     "coveralls": "2.11.16",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,9 +2,9 @@
 # yarn lockfile v1
 
 
-"@centerforopenscience/ember-osf@https://github.com/CenterForOpenScience/ember-osf.git#develop#2017-08-02T14:36:24Z":
+"@centerforopenscience/ember-osf@https://github.com/CenterForOpenScience/ember-osf.git#develop#2017-08-02T22:23:33Z":
   version "0.7.1"
-  resolved "https://github.com/CenterForOpenScience/ember-osf.git#9648ec2660735c11f59026b840189c42d2fae9d6"
+  resolved "https://github.com/CenterForOpenScience/ember-osf.git#2a2d5cf2f8bbc02eecdae238672ff1287b0e83f6"
   dependencies:
     broccoli-funnel "1.2.0"
     broccoli-merge-trees "2.0.0"


### PR DESCRIPTION
## Ticket

https://openscience.atlassian.net/browse/EOSF-691

## Purpose

Use path for highlighted taxonomies link so that we have the full hierarchy

## Changes

Use subject.path in highlighted taxonomies link

## Testing notes

Make sure clicking on highlighted taxonomies that are children results in proper filter on discover page