### PR TITLE
[EOSF-778] Remove donate banner from branded preprints

### DIFF
--- a/app/templates/application.hbs
+++ b/app/templates/application.hbs
@@ -18,7 +18,9 @@
 
 {{maintenance-banner}}
 
-{{donate-banner}}
+{{#unless theme.isProvider}}
+    {{donate-banner}}
+{{/unless}}
 
 {{outlet}}
 


### PR DESCRIPTION
## Purpose

To remove the donate banner from branded preprints.

## Changes

Add a conditional to check if the preprint provider is branded.