### PR TITLE
[EOSF-778] Remove banner except on preprints landing page

### DIFF
--- a/app/templates/application.hbs
+++ b/app/templates/application.hbs
@@ -18,10 +18,6 @@
 
 {{maintenance-banner}}
 
-{{#unless theme.isProvider}}
-    {{donate-banner}}
-{{/unless}}
-
 {{outlet}}
 
 {{#if theme.isProvider}}

--- a/app/templates/index.hbs
+++ b/app/templates/index.hbs
@@ -1,3 +1,7 @@
+{{#unless theme.isProvider}}
+    {{donate-banner}}
+{{/unless}}
+
 <div class="preprints-page"> {{!INDEX}}
 
     {{!HEADER}}


### PR DESCRIPTION
## Purpose

The banner should not show up except on landing pages.

## Changes

Remove the donate banner from the main application page and move it to the landing page.