### PR TITLE
[Feature] Add zotero update event trigger [OSF-8265]

### DIFF
--- a/app/routes/content/index.js
+++ b/app/routes/content/index.js
@@ -257,6 +257,11 @@ export default Ember.Route.extend(Analytics, ResetScrollMixin, SetupSubmitContro
 
                 return this.intermediateTransitionTo(page);
             }
+        },
+        didTransition() {
+            const ev = document.createEvent('HTMLEvents');
+            ev.initEvent('ZoteroItemUpdated', true, true);
+            document.dispatchEvent(ev);
         }
     }
 });


### PR DESCRIPTION
## Ticket

[OSF-8265](https://openscience.atlassian.net/browse/OSF-8265)

## Purpose

Enable osf preprints metatags to be picked up by Zotero Connector (browser extension)
Problem statement is well documented [here](https://forums.zotero.org/discussion/comment/279664)

## Changes

Fires event trigger that forces zotero picker to refresh/parse anew after normal
hooks are done.

## Before

![before-zotero-fix](https://user-images.githubusercontent.com/4511563/29132332-de4b208e-7cfd-11e7-851b-a26d6d548c2d.gif)

![before-zotero-fix-2](https://user-images.githubusercontent.com/4511563/29132343-e6d7ba78-7cfd-11e7-969c-f4f4d8700b8a.gif)

## After

![after-zotero-fix](https://user-images.githubusercontent.com/4511563/29132363-f54f81da-7cfd-11e7-9b04-bab22707a841.gif)

![after-zotero-fix-2](https://user-images.githubusercontent.com/4511563/29132364-f5721632-7cfd-11e7-8adf-2d4314b94e0b.gif)
