### PR TITLE
[EOSF-773] Provider carousel link to domain with redirect enabled

### DIFF
--- a/app/helpers/branded-preprint-url.js
+++ b/app/helpers/branded-preprint-url.js
@@ -1,0 +1,25 @@
+import Ember from 'ember';
+import pathJoin from '../utils/path-join';
+
+/**
+ * @module ember-preprints
+ * @submodule helpers
+ */
+
+/**
+ * To determine the link url for branded preprints on the provider carousel
+ *
+ * @class route-prefix
+ */
+
+export function brandedPreprintUrl(provider, lightLogo) {
+    let url = '';
+    if (provider[0].get('domain') && provider[0].get('domainRedirectEnabled')) {
+        url = lightLogo.type ? provider[0].get('domain') : pathJoin(provider[0].get('domain'), 'discover');
+    } else {
+        url = lightLogo.type ? '/preprints/' + provider[0].get('id') : '/preprints/' + provider[0].get('id') + '/discover';
+    }
+    return url;
+}
+
+export default Ember.Helper.helper(brandedPreprintUrl);

--- a/app/helpers/branded-preprint-url.js
+++ b/app/helpers/branded-preprint-url.js
@@ -6,12 +6,17 @@ import pathJoin from '../utils/path-join';
  * @submodule helpers
  */
 
-/**
- * To determine the link url for branded preprints on the provider carousel
- *
- * @class route-prefix
- */
-
+ /**
+  * To determine the link url for branded preprints on the provider carousel
+  * Returns a string of the url with the necessary path
+  *
+  * @class brandedPreprintUrl
+  * @param {Object[]} params all positional parameters.
+  * @param {Object} params[0] The provider the url is being generated for.
+  * @param {Object} hash all named parameters.
+  * @param {String} hash.path The path to append.
+  * @return {String} The url.
+  */
 export function brandedPreprintUrl(params, hash) {
     let url = '';
     let [provider] = params;

--- a/app/helpers/branded-preprint-url.js
+++ b/app/helpers/branded-preprint-url.js
@@ -12,12 +12,16 @@ import pathJoin from '../utils/path-join';
  * @class route-prefix
  */
 
-export function brandedPreprintUrl(provider, lightLogo) {
+export function brandedPreprintUrl(params, hash) {
     let url = '';
-    if (provider[0].get('domain') && provider[0].get('domainRedirectEnabled')) {
-        url = lightLogo.type ? provider[0].get('domain') : pathJoin(provider[0].get('domain'), 'discover');
+    let [provider] = params;
+    if (provider.get('domain') && provider.get('domainRedirectEnabled')) {
+        url = provider.get('domain');
     } else {
-        url = lightLogo.type ? '/preprints/' + provider[0].get('id') : '/preprints/' + provider[0].get('id') + '/discover';
+        url = '/preprints/' + provider.get('id');
+    }
+    if (hash.path) {
+        return pathJoin(url, hash.path);
     }
     return url;
 }

--- a/app/templates/components/provider-carousel.hbs
+++ b/app/templates/components/provider-carousel.hbs
@@ -5,19 +5,27 @@
             <div class={{if (not index) "item active" "item"}}>
                 {{#each slide as |provider index|}}
                     <div class={{if (not index) (concat "col-sm-2 " columnOffset) "col-sm-2"}}>
-                        {{#if lightLogo}}
-                            <a href="/preprints/{{provider.id}}"
+                        {{#if (and provider.domain provider.domainRedirectEnabled)}}
+                            <a href="{{provider.domain}}{{if lightLogo '' '/discover'}}"
                                 title={{provider.name}}
                                 onclick={{action 'click' 'link' (concat 'Index - Provider Carousel - ' provider.name)}}
                                 >
-                                <div class="provider-logo provider-{{provider.id}}" style="background-image: url('{{providerAsset provider.id 'wide_white.png'}}')"></div>
+                                {{#if lightLogo}}
+                                    <div class="provider-logo provider-{{provider.id}}" style="background-image: url('{{providerAsset provider.id 'wide_white.png'}}')"></div>
+                                {{else}}
+                                    <div class="discover-provider-logo provider-{{provider.id}}-dark" style="background-image: url('{{providerAsset provider.id 'wide_black.png'}}')"></div>
+                                {{/if}}
                             </a>
                         {{else}}
-                            <a href="/preprints/{{provider.id}}/discover"
+                            <a href="/preprints/{{provider.id}}{{if lightLogo '' '/discover'}}"
                                 title={{provider.name}}
                                 onclick={{action 'click' 'link' (concat 'Discover - Provider Carousel ' provider.name)}}
-                            >
-                                <div class="discover-provider-logo provider-{{provider.id}}-dark" style="background-image: url('{{providerAsset provider.id 'wide_black.png'}}')"></div>
+                                >
+                                {{#if lightLogo}}
+                                    <div class="provider-logo provider-{{provider.id}}" style="background-image: url('{{providerAsset provider.id 'wide_white.png'}}')"></div>
+                                {{else}}
+                                    <div class="discover-provider-logo provider-{{provider.id}}-dark" style="background-image: url('{{providerAsset provider.id 'wide_black.png'}}')"></div>
+                                {{/if}}
                             </a>
                         {{/if}}
                     </div>

--- a/app/templates/components/provider-carousel.hbs
+++ b/app/templates/components/provider-carousel.hbs
@@ -5,29 +5,16 @@
             <div class={{if (not index) "item active" "item"}}>
                 {{#each slide as |provider index|}}
                     <div class={{if (not index) (concat "col-sm-2 " columnOffset) "col-sm-2"}}>
-                        {{#if (and provider.domain provider.domainRedirectEnabled)}}
-                            <a href="{{provider.domain}}{{if lightLogo '' '/discover'}}"
-                                title={{provider.name}}
-                                onclick={{action 'click' 'link' (concat 'Index - Provider Carousel - ' provider.name)}}
-                                >
-                                {{#if lightLogo}}
-                                    <div class="provider-logo provider-{{provider.id}}" style="background-image: url('{{providerAsset provider.id 'wide_white.png'}}')"></div>
-                                {{else}}
-                                    <div class="discover-provider-logo provider-{{provider.id}}-dark" style="background-image: url('{{providerAsset provider.id 'wide_black.png'}}')"></div>
-                                {{/if}}
-                            </a>
-                        {{else}}
-                            <a href="/preprints/{{provider.id}}{{if lightLogo '' '/discover'}}"
-                                title={{provider.name}}
-                                onclick={{action 'click' 'link' (concat 'Discover - Provider Carousel ' provider.name)}}
-                                >
-                                {{#if lightLogo}}
-                                    <div class="provider-logo provider-{{provider.id}}" style="background-image: url('{{providerAsset provider.id 'wide_white.png'}}')"></div>
-                                {{else}}
-                                    <div class="discover-provider-logo provider-{{provider.id}}-dark" style="background-image: url('{{providerAsset provider.id 'wide_black.png'}}')"></div>
-                                {{/if}}
-                            </a>
-                        {{/if}}
+                        <a href="{{brandedPreprintUrl provider type=lightLogo}}"
+                            title={{provider.name}}
+                            onclick={{action 'click' 'link' (concat 'Index - Provider Carousel - ' provider.name)}}
+                            >
+                            {{#if lightLogo}}
+                                <div class="provider-logo provider-{{provider.id}}" style="background-image: url('{{providerAsset provider.id 'wide_white.png'}}')"></div>
+                            {{else}}
+                                <div class="discover-provider-logo provider-{{provider.id}}-dark" style="background-image: url('{{providerAsset provider.id 'wide_black.png'}}')"></div>
+                            {{/if}}
+                        </a>
                     </div>
                 {{/each}}
             </div>

--- a/app/templates/components/provider-carousel.hbs
+++ b/app/templates/components/provider-carousel.hbs
@@ -5,7 +5,7 @@
             <div class={{if (not index) "item active" "item"}}>
                 {{#each slide as |provider index|}}
                     <div class={{if (not index) (concat "col-sm-2 " columnOffset) "col-sm-2"}}>
-                        <a href="{{brandedPreprintUrl provider type=lightLogo}}"
+                        <a href="{{brandedPreprintUrl provider path=(if lightLogo '' '/discover')}}"
                             title={{provider.name}}
                             onclick={{action 'click' 'link' (concat 'Index - Provider Carousel - ' provider.name)}}
                             >


### PR DESCRIPTION
## Ticket

https://openscience.atlassian.net/browse/EOSF-773

## Purpose

When a provider has a domain and has domain_redirect_enabled set to true, it should link to it's domain instead of use an osf.io url.

## Changes

Added a conditional to check the domain and redirect settings for providers in the carousel.

## Testing

To test this, be sure to have a provider with both a domain and domain_redirect_enabled set to true.  The final result should look like this on preprints:
<img width="1440" alt="screen shot 2017-08-14 at 10 58 23 am" src="https://user-images.githubusercontent.com/19379783/29277487-c42686f4-80df-11e7-990e-f59339e558a0.png">
<img width="1440" alt="screen shot 2017-08-14 at 10 55 13 am" src="https://user-images.githubusercontent.com/19379783/29277491-c6897f1e-80df-11e7-8dcd-8492f22a7631.png">

