### PR TITLE
Hotfix/0.111.15 [EOSF-655]

### DIFF
--- a/app/services/theme.js
+++ b/app/services/theme.js
@@ -53,6 +53,11 @@ export default Ember.Service.extend({
         return this.get('id') !== 'osf';
     }),
 
+    // If we should include the preprint word in the title
+    preprintWordInTitle: Ember.computed('id', function() {
+        return this.get('id') !== 'thesiscommons';
+    }),
+
     // If we're using a branded provider and not under a branded domain (e.g. /preprints/<provider>)
     isSubRoute: Ember.computed('isProvider', 'isDomain', function() {
         return this.get('isProvider') && !this.get('isDomain');

--- a/app/templates/application.hbs
+++ b/app/templates/application.hbs
@@ -1,4 +1,4 @@
-{{title (t (if theme.isProvider 'global.provider_brand' 'global.brand') name=theme.provider.name) separator=(t 'application.separator')}}
+{{title (if theme.isProvider (if theme.preprintWordInTitle (t 'global.provider_brand' name=theme.provider.name) theme.provider.name) (t 'global.brand')) separator=(t 'application.separator')}}
 
 {{#if theme.isProvider}}
     <style>

--- a/app/templates/components/preprint-navbar-branded.hbs
+++ b/app/templates/components/preprint-navbar-branded.hbs
@@ -7,7 +7,7 @@
         </button>
         {{#link-to (route-prefix 'index') slug=theme.id class="navbar-brand" invokeAction=(action "click" "link" "Navbar - Brand")~}}
             <span class="navbar-image" style="background-image: url('{{providerAsset theme.id 'square_color_transparent.png'}}')"></span>
-            <span class="navbar-title">{{model.name}} {{t "global.preprints"}}</span>
+            <span class="navbar-title">{{model.name}}{{#if theme.preprintWordInTitle}} {{t "global.preprints"}}{{/if}}</span>
         {{~/link-to}}
     </div>
     <div id="preprint-navbar-links" class="navbar-collapse collapse navbar-right">

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "preprint-service",
-  "version": "0.111.14",
+  "version": "0.111.15",
   "description": "Center for Open Science Preprint Service",
   "private": true,
   "directories": {


### PR DESCRIPTION
## Ticket

https://openscience.atlassian.net/browse/EOSF-655 

## Purpose

Hide "Theses" from page title and nav bar for Thesis Commons

## Changes

* add property to theme service for determining if the preprint word should be included in the title
* use this property to determine when to include the preprint word in the:
  * page title
  * nav bar

## Side effects

N/A



