### PR TITLE
Hotfix/0.111.16 [EOSF-814]

### DIFF
--- a/app/components/search-facet-provider.js
+++ b/app/components/search-facet-provider.js
@@ -30,6 +30,7 @@ export default Ember.Component.extend(Analytics, {
     otherProviders: [],
     searchUrl: config.OSF.shareSearchUrl,
     whiteListedProviders: config.whiteListedProviders,
+    osfUrl: config.OSF.url,
 
     init() {
         this._super(...arguments);

--- a/app/templates/components/search-facet-provider.hbs
+++ b/app/templates/components/search-facet-provider.hbs
@@ -10,7 +10,7 @@
             </li>
         {{/each}}
         {{#if theme.isProvider}}
-            <a href="/preprints/discover" onbeforeclick={{action 'click' 'link' 'Discover - Other Preprint Repositories'}}>{{t "discover.main.otherRepositories"}}</a>
+            <a href="{{osfUrl}}preprints/discover" onbeforeclick={{action 'click' 'link' 'Discover - Other Preprint Repositories'}}>{{t "discover.main.otherRepositories"}}</a>
         {{/if}}
     </ul>
 </div>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "preprint-service",
-  "version": "0.111.15",
+  "version": "0.111.16",
   "description": "Center for Open Science Preprint Service",
   "private": true,
   "directories": {


### PR DESCRIPTION
## Ticket

https://openscience.atlassian.net/browse/EOSF-814

## Purpose

"Other Preprint Repositories" should always link to the OSF domain, even when on a branded domain.

## Changes

Use OSF.url in the link.

## Side effects

Should do the right thing in all environments.



