### PR TITLE
[EOSF-667] Add 'thesis' as possible SHARE publication type

### DIFF
--- a/app/components/search-facet-provider.js
+++ b/app/components/search-facet-provider.js
@@ -2,7 +2,7 @@ import Ember from 'ember';
 import config from 'ember-get-config';
 import Analytics from 'ember-osf/mixins/analytics';
 
-var getProvidersPayload = '{"from": 0,"query": {"bool": {"must": {"query_string": {"query": "*"}}, "filter": [{"term": {"types": "preprint"}}]}},"aggregations": {"sources": {"terms": {"field": "sources","size": 200}}}}';
+var getProvidersPayload = '{"from": 0,"query": {"bool": {"must": {"query_string": {"query": "*"}}, "filter": [{"terms": {"types": ["preprint", "thesis"]}}]}},"aggregations": {"sources": {"terms": {"field": "sources","size": 200}}}}';
 
 /**
  * @module ember-preprints

--- a/app/controllers/discover.js
+++ b/app/controllers/discover.js
@@ -59,7 +59,7 @@ export default Ember.Controller.extend(Analytics, {
     },
     lockedParams: Ember.computed('additionalProviders', function() { // Query parameters that cannot be changed.
         // if additionalProviders, open up search results to all types of results instead of just preprints.
-        return this.get('additionalProviders') ? {} : {types: 'preprint'};
+        return this.get('additionalProviders') ? {} : {types: ['preprint', 'thesis']};
     }),
     page: 1, // Page query param. Must be passed to component, so can be reflected in URL
     provider: '', // Provider query param. Must be passed to component, so can be reflected in URL

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   "author": "",
   "license": "Apache-2.0",
   "devDependencies": {
-    "@centerforopenscience/ember-osf": "https://github.com/CenterForOpenScience/ember-osf.git#develop#2017-08-22T20:22:43Z",
+    "@centerforopenscience/ember-osf": "https://github.com/CenterForOpenScience/ember-osf.git#develop#2017-08-24T15:47:21Z",
     "autoprefixer": "6.3.7",
     "broccoli-asset-rev": "2.4.2",
     "coveralls": "2.11.16",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,9 +2,9 @@
 # yarn lockfile v1
 
 
-"@centerforopenscience/ember-osf@https://github.com/CenterForOpenScience/ember-osf.git#develop#2017-08-22T20:22:43Z":
+"@centerforopenscience/ember-osf@https://github.com/CenterForOpenScience/ember-osf.git#develop#2017-08-24T15:47:21Z":
   version "0.9.1"
-  resolved "https://github.com/CenterForOpenScience/ember-osf.git#a77296c03dad47f5c616f756ce19e8048e5b58c8"
+  resolved "https://github.com/CenterForOpenScience/ember-osf.git#5a84342146c0b4afa1fe8bfb4d9b113ff094f35b"
   dependencies:
     broccoli-funnel "1.2.0"
     broccoli-merge-trees "2.0.0"


### PR DESCRIPTION
## Ticket

https://openscience.atlassian.net/browse/EOSF-667

## Purpose

Add `thesis` as a possible SHARE publication type to be used for filtering on the discover page.

## Changes

- Add `thesis` as one of the publication types to be filtered
- Add `thesis` to the search-facet to return results for providers that have theses