### PR TITLE
[EOSF-820] Remove arXiv license permission language

### DIFF
--- a/app/services/theme.js
+++ b/app/services/theme.js
@@ -121,13 +121,4 @@ export default Ember.Service.extend({
     redirectUrl: Ember.computed('currentLocation', function() {
         return this.get('currentLocation');
     }),
-
-    // The translation key for the provider's permission language
-    permissionLanguage: Ember.computed('id', function() {
-        const id = this.get('id');
-
-        return config.PREPRINTS.providers
-            .find(provider => provider.id === id)
-            .permissionLanguage;
-    }),
 });

--- a/app/styles/app.scss
+++ b/app/styles/app.scss
@@ -1208,12 +1208,6 @@ nav.branded-navbar {
     }
 }
 
-.permission-footer-language {
-    margin-top: 1em;
-    margin-bottom: 1em;
-    line-height: 28px;
-  }
-
 .branded-footer-links {
     margin-bottom: 1em;
     line-height: 28px;

--- a/app/templates/components/preprint-footer-branded.hbs
+++ b/app/templates/components/preprint-footer-branded.hbs
@@ -7,7 +7,3 @@
 
 
 {{osf-copyright class='text-center'}}
-
-<div class="text-center permission-footer-language ">
-    <span>{{t (concat "components.permission-language." theme.permissionLanguage) provider=model.name}}</span>
-</div>

--- a/config/environment.js
+++ b/config/environment.js
@@ -48,80 +48,61 @@ module.exports = function(environment) {
                         type: 'image/png',
                         width: 363,
                         height: 242
-                    },
-                    permissionLanguage: 'no_trademark'
+                    }
                 },
                 {
-                    id: 'engrxiv',
-                    permissionLanguage: 'arxiv_non_endorsement'
+                    id: 'engrxiv'
                 },
                 {
-                    id: 'socarxiv',
-                    permissionLanguage: 'arxiv_trademark_license'
+                    id: 'socarxiv'
                 },
                 {
-                    id: 'psyarxiv',
-                    permissionLanguage: 'arxiv_trademark_license'
+                    id: 'psyarxiv'
                 },
                 {
-                    id: 'bitss',
-                    permissionLanguage: 'no_trademark'
+                    id: 'bitss'
                 },
                 {
-                    id: 'scielo',
-                    permissionLanguage: 'no_trademark'
+                    id: 'scielo'
                 },
                 {
-                    id: 'agrixiv',
-                    permissionLanguage: 'arxiv_non_endorsement'
+                    id: 'agrixiv'
                 },
                 {
-                    id: 'lawarxiv',
-                    permissionLanguage: 'arxiv_non_endorsement'
+                    id: 'lawarxiv'
                 },
                 {
-                    id: 'focusarchive',
-                    permissionLanguage: 'no_trademark'
+                    id: 'focusarchive'
                 },
                 {
-                    id: 'paleorxiv',
-                    permissionLanguage: 'arxiv_non_endorsement'
+                    id: 'paleorxiv'
                 },
                 {
-                    id: 'mindrxiv',
-                    permissionLanguage: 'no_trademark'
+                    id: 'mindrxiv'
                 },
                 {
-                    id: 'lissa',
-                    permissionLanguage: 'no_trademark'
+                    id: 'lissa'
                 },
                 {
-                    id: 'sportrxiv',
-                    permissionLanguage: 'no_trademark'
+                    id: 'sportrxiv'
                 },
                 {
-                    id: 'thesiscommons',
-                    permissionLanguage: 'no_trademark'
+                    id: 'thesiscommons'
                 },
                 {
-                    id: 'asu',
-                    permissionLanguage: 'no_trademark'
+                    id: 'asu'
                 },
                 {
-                    id: 'nutrixiv',
-                    permissionLanguage: 'no_trademark'
+                    id: 'nutrixiv'
                 },
                 {
-                    id: 'inarxiv',
-                    permissionLanguage: 'no_trademark'
+                    id: 'inarxiv'
                 },
                 {
-                    id: 'medarxiv',
-                    permissionLanguage: 'no_trademark'
+                    id: 'medarxiv'
                 },
                 {
-                    id: 'experimentalprotocols',
-                    permissionLanguage: 'no_trademark'
+                    id: 'experimentalprotocols'
                 }
             ],
         },

--- a/tests/unit/services/theme-test.js
+++ b/tests/unit/services/theme-test.js
@@ -16,6 +16,5 @@ test('themes have proper config', function(assert) {
     let providers = config.PREPRINTS.providers;
     for (var provider of providers) {
         assert.ok(typeof provider.id !== 'undefined');
-        assert.ok(typeof provider.permissionLanguage !== 'undefined');
     }
 });


### PR DESCRIPTION
## Ticket

https://openscience.atlassian.net/browse/EOSF-820

## Purpose

Remove arXiv trademark license permission language

## Changes

Removed arXiv trademark license permission language

## Side effects

arXiv trademark license permission language will no longer appear in the footer for branded preprints (unless it is added to footer_links, and then it will appear above the copyright notice).


