### PR TITLE
[EOSF-818] Hide overflow and use ellipsis for long highlighted taxonomies

### DIFF
--- a/app/styles/app.scss
+++ b/app/styles/app.scss
@@ -158,6 +158,8 @@ ul.comma-list {
     .subject-item a {
         width: 100%;
         font-size: 17px;
+        overflow: hidden;
+        text-overflow: ellipsis;
     }
 }
 


### PR DESCRIPTION
## Ticket

https://openscience.atlassian.net/browse/EOSF-818

## Purpose

Hide overflow and use ellipsis for long highlighted taxonomy names.

## Changes

Added `overflow: hidden` and `text-overflow: ellipsis` to style for highlighted taxonomies

## Side effects

None



