### PR TITLE
[EOSF-819] Move branded domain lookup to application route's beforeModel hook

### DIFF
--- a/app/router.js
+++ b/app/router.js
@@ -5,27 +5,7 @@ const Router = Ember.Router.extend({
     location: config.locationType,
     rootURL: config.rootURL,
     metrics: Ember.inject.service(),
-    store: Ember.inject.service(),
     theme: Ember.inject.service(),
-
-    init() {
-        this._super(...arguments);
-
-        // Set the provider ID from the current origin
-        if (window.isProviderDomain) {
-            return this.get('store')
-                .query('preprint-provider', {
-                    filter: {
-                        domain: `${window.location.origin}/`,
-                    }
-                })
-                .then(providers => {
-                    if (providers.length) {
-                        this.set('theme.id', providers.objectAt(0).get('id'));
-                    }
-                });
-        }
-    },
 
     didTransition() {
         this._super(...arguments);

--- a/app/routes/application.js
+++ b/app/routes/application.js
@@ -13,6 +13,27 @@ import Analytics from 'ember-osf/mixins/analytics';
  */
 export default Ember.Route.extend(Analytics, OSFAgnosticAuthRouteMixin, {
     i18n: Ember.inject.service(),
+    store: Ember.inject.service(),
+    theme: Ember.inject.service(),
+
+    beforeModel: function () {
+        // Set the provider ID from the current origin
+        if (window.isProviderDomain) {
+            return this.get('store').query(
+                'preprint-provider',
+                {
+                    filter: {
+                        domain: `${window.location.origin}/`,
+                    }
+                }
+            ).then(providers => {
+                if (providers.length) {
+                    this.set('theme.id', providers.objectAt(0).get('id'));
+                }
+            });
+        }
+    },
+
     afterModel: function() {
         const availableLocales = this.get('i18n.locales').toArray();
         let locale;


### PR DESCRIPTION
## Ticket

https://openscience.atlassian.net/browse/EOSF-819

## Purpose

Make sure the theme id is set to the provider that matches the branded domain before looking up highlighted taxonomies.

## Changes

Moved branded domain lookup to application route's beforeModel hook.

## Side effects

When a branded domain is detected, routing will pause until the API query returns the provider for the domain.

## Testing notes

Unable to replicate the issue on staging (only seen on production) but just make sure branded domains still work properly.