### PR TITLE
[EOSF-782] Filter out ASU for search facet providers

### DIFF
--- a/app/components/search-facet-provider.js
+++ b/app/components/search-facet-provider.js
@@ -39,13 +39,14 @@ export default Ember.Component.extend(Analytics, {
             this.get('store')
                 .findAll('preprint-provider')
                 .then(providers => {
-                    const providerNames = providers.map(provider => {
+                    const providerNames = providers.filter(
+                        provider => provider.get('id') !== 'asu'
+                    ).map(provider => {
                         const name = provider.get('name');
                         // TODO Change this in populate_preprint_providers script to just OSF
                         return name === 'Open Science Framework' ? 'OSF' : name;
                     });
                     this.set('osfProviders', providerNames);
-
                     return providerNames;
                 }),
             // The providers list from SHARE


### PR DESCRIPTION
## Ticket

https://openscience.atlassian.net/browse/EOSF-782

## Purpose

To remove ASU as a possible provider to filter results by on the discover page.

## Changes

Add a filter when returning results to specifically filter out ASU.

## QA

The change is just to filter out ASU, so the only thing you'll really need to check is whether or not it shows up in the list.
<img width="1440" alt="screen shot 2017-08-24 at 2 26 01 pm" src="https://user-images.githubusercontent.com/19379783/29682235-4d5dfc2c-88d8-11e7-9f21-8169f98a5e1c.png">




