### PR TITLE
[EOSF-827] Check provider route slug against API

### DIFF
--- a/app/routes/provider.js
+++ b/app/routes/provider.js
@@ -1,9 +1,6 @@
 import Ember, { Logger } from 'ember';
 import config from 'ember-get-config';
 
-const providers = config.PREPRINTS.providers.slice(1);
-const providerIds = providers.map(p => p.id);
-
 /**
  * @module ember-preprints
  * @submodule routes
@@ -19,19 +16,21 @@ export default Ember.Route.extend({
         const {slug = ''} = transition.params.provider;
         const slugLower = slug.toLowerCase();
 
-        if (providerIds.includes(slugLower)) {
-            if (slugLower !== slug) {
-                const {pathname} = window.location;
-                const pathRegex = new RegExp(`^/preprints/${slug}`);
+        return this.get('store').findRecord(
+            'preprint-provider',
+            slugLower
+        ).then(() => {
+            const {pathname} = window.location;
+            const pathRegex = new RegExp(`^/preprints/${slug}`);
 
+            if (slug !== slugLower) {
                 window.location.pathname = pathname.replace(
                     pathRegex,
                     `/preprints/${slugLower}`
                 );
             }
-
-            this.set('theme.id', slug);
-        } else {
+            this.set('theme.id', slugLower);
+        }).catch(() => {
             this.set('theme.id', config.PREPRINTS.defaultProvider);
 
             if (slug.length === 5) {
@@ -39,7 +38,7 @@ export default Ember.Route.extend({
             } else {
                 this.replaceWith('page-not-found');
             }
-        }
+        });
     },
 
     actions: {

--- a/config/environment.js
+++ b/config/environment.js
@@ -49,60 +49,6 @@ module.exports = function(environment) {
                         width: 363,
                         height: 242
                     }
-                },
-                {
-                    id: 'engrxiv'
-                },
-                {
-                    id: 'socarxiv'
-                },
-                {
-                    id: 'psyarxiv'
-                },
-                {
-                    id: 'bitss'
-                },
-                {
-                    id: 'scielo'
-                },
-                {
-                    id: 'agrixiv'
-                },
-                {
-                    id: 'lawarxiv'
-                },
-                {
-                    id: 'focusarchive'
-                },
-                {
-                    id: 'paleorxiv'
-                },
-                {
-                    id: 'mindrxiv'
-                },
-                {
-                    id: 'lissa'
-                },
-                {
-                    id: 'sportrxiv'
-                },
-                {
-                    id: 'thesiscommons'
-                },
-                {
-                    id: 'asu'
-                },
-                {
-                    id: 'nutrixiv'
-                },
-                {
-                    id: 'inarxiv'
-                },
-                {
-                    id: 'medarxiv'
-                },
-                {
-                    id: 'experimentalprotocols'
                 }
             ],
         },


### PR DESCRIPTION
## Ticket

https://openscience.atlassian.net/browse/EOSF-827

## Purpose

Check provider route slug against API

## Changes

Check provider route slug against API

## Side effects

Branded provider pages will not load until they get a response from the API. This is, however, already the case for the index and discover pages.

## Testing notes

Make sure all branded provider pages load properly.

