### PR TITLE
[EOSF-833] Call parent's beforeModel() in application route

### DIFF
--- a/app/routes/application.js
+++ b/app/routes/application.js
@@ -17,21 +17,26 @@ export default Ember.Route.extend(Analytics, OSFAgnosticAuthRouteMixin, {
     theme: Ember.inject.service(),
 
     beforeModel: function () {
-        // Set the provider ID from the current origin
-        if (window.isProviderDomain) {
-            return this.get('store').query(
-                'preprint-provider',
-                {
-                    filter: {
-                        domain: `${window.location.origin}/`,
+        let detectBrandedDomain = () => {
+            // Set the provider ID from the current origin
+            if (window.isProviderDomain) {
+                return this.get('store').query(
+                    'preprint-provider',
+                    {
+                        filter: {
+                            domain: `${window.location.origin}/`,
+                        }
                     }
-                }
-            ).then(providers => {
-                if (providers.length) {
-                    this.set('theme.id', providers.objectAt(0).get('id'));
-                }
-            });
-        }
+                ).then(providers => {
+                    if (providers.length) {
+                        this.set('theme.id', providers.objectAt(0).get('id'));
+                    }
+                });
+            }
+        };
+        let parentResult = this._super(...arguments);
+        // Chain on to parent's promise if parent returns a promise.
+        return parentResult instanceof Promise ? parentResult.then(detectBrandedDomain) : detectBrandedDomain();
     },
 
     afterModel: function() {


### PR DESCRIPTION
## Ticket

https://openscience.atlassian.net/browse/EOSF-833

## Purpose

Fix authentication for preprints

## Changes

Call parent's beforeModel() in application route

## Side effects

Authentication should work properly again



