### PR TITLE
[EOSF-736] Update to get osf-style from node_modules

### DIFF
--- a/app/styles/app.scss
+++ b/app/styles/app.scss
@@ -2,7 +2,7 @@
 @import 'variables';
 @import 'bootstrap';
 @import 'ember-power-select';
-@import 'base';
+@import 'osf-style';
 @import 'authors';
 @import 'validated-input';
 @import 'hint';

--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -6,6 +6,7 @@ const fs = require('fs');
 const path = require('path');
 const EmberApp = require('ember-cli/lib/broccoli/ember-app');
 const configFunc = require('./config/environment');
+const Funnel = require('broccoli-funnel');
 
 const nonCdnEnvironments = ['development', 'test'];
 
@@ -60,7 +61,7 @@ module.exports = function(defaults) {
             includePaths: [
                 'node_modules/@centerforopenscience/ember-osf/addon/styles',
                 'bower_components/bootstrap-sass/assets/stylesheets',
-                'bower_components/osf-style/sass',
+                'node_modules/@centerforopenscience/osf-style/sass',
                 'bower_components/hint.css',
                 'bower_components/c3',
                 'bower_components/bootstrap-daterangepicker',
@@ -126,15 +127,7 @@ module.exports = function(defaults) {
     // along with the exports of each module as its value.
 
     // osf-style
-    app.import(path.join(app.bowerDirectory, 'osf-style/vendor/prism/prism.css'));
-    app.import(path.join(app.bowerDirectory, 'osf-style/page.css'));
-    app.import(path.join(app.bowerDirectory, 'osf-style/css/base.css'));
     app.import(path.join(app.bowerDirectory, 'loaders.css/loaders.min.css'));
-
-
-    app.import(path.join(app.bowerDirectory, 'osf-style/img/cos-white2.png'), {
-        destDir: 'img'
-    });
 
     // app.import('bower_components/dropzone/dist/dropzone.js');
     app.import({
@@ -159,5 +152,12 @@ module.exports = function(defaults) {
     // Import component styles from addon
     app.import('vendor/assets/ember-osf.css');
 
-    return app.toTree();
+    const assets = [
+        new Funnel('node_modules/@centerforopenscience/osf-style/img', {
+            srcDir: '/',
+            destDir: 'img',
+        })
+    ];
+
+    return app.toTree(assets);
 };

--- a/package.json
+++ b/package.json
@@ -94,5 +94,8 @@
   "bugs": {
     "url": "https://github.com/CenterForOpenScience/ember-preprints/issues"
   },
-  "homepage": "https://github.com/CenterForOpenScience/ember-preprints#readme"
+  "homepage": "https://github.com/CenterForOpenScience/ember-preprints#readme",
+  "dependencies": {
+    "@centerforopenscience/osf-style": "1.4.2"
+  }
 }

--- a/package.json
+++ b/package.json
@@ -29,7 +29,8 @@
   "author": "",
   "license": "Apache-2.0",
   "devDependencies": {
-    "@centerforopenscience/ember-osf": "0.10.2",
+    "@centerforopenscience/ember-osf": "https://github.com/CenterForOpenScience/ember-osf.git#develop#2017-09-13T14:33:43Z",
+    "@centerforopenscience/osf-style": "1.5.0",
     "autoprefixer": "6.3.7",
     "broccoli-asset-rev": "2.4.2",
     "coveralls": "2.11.16",
@@ -94,8 +95,5 @@
   "bugs": {
     "url": "https://github.com/CenterForOpenScience/ember-preprints/issues"
   },
-  "homepage": "https://github.com/CenterForOpenScience/ember-preprints#readme",
-  "dependencies": {
-    "@centerforopenscience/osf-style": "1.4.2"
-  }
+  "homepage": "https://github.com/CenterForOpenScience/ember-preprints#readme"
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,9 +2,9 @@
 # yarn lockfile v1
 
 
-"@centerforopenscience/ember-osf@0.10.2":
+"@centerforopenscience/ember-osf@https://github.com/CenterForOpenScience/ember-osf.git#develop#2017-09-13T14:33:43Z":
   version "0.10.2"
-  resolved "https://registry.yarnpkg.com/@centerforopenscience/ember-osf/-/ember-osf-0.10.2.tgz#c7ad63216264b054beb2a9e6683bcad8075be06c"
+  resolved "https://github.com/CenterForOpenScience/ember-osf.git#d1be029cdbc58fc0a5a05f1b21b8b542ac50559a"
   dependencies:
     broccoli-funnel "1.2.0"
     broccoli-merge-trees "2.0.0"
@@ -31,9 +31,9 @@
     keen-tracking "1.1.3"
     langs "1.0.2"
 
-"@centerforopenscience/osf-style@1.4.2":
-  version "1.4.2"
-  resolved "https://registry.yarnpkg.com/@centerforopenscience/osf-style/-/osf-style-1.4.2.tgz#f5db9926a5cb41a6a5d31580e0f217799355ab39"
+"@centerforopenscience/osf-style@1.5.0":
+  version "1.5.0"
+  resolved "https://registry.yarnpkg.com/@centerforopenscience/osf-style/-/osf-style-1.5.0.tgz#b4145f2a5222a5f8e21b4589e27770f85aed04fe"
 
 JSONStream@^1.0.3:
   version "1.3.1"
@@ -3420,13 +3420,13 @@ ember-toastr@1.4.1:
   dependencies:
     ember-cli-babel "^5.0.0"
 
-ember-truth-helpers@1.2.0:
+ember-truth-helpers@1.2.0, ember-truth-helpers@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/ember-truth-helpers/-/ember-truth-helpers-1.2.0.tgz#e63cffeaa8211882ae61a958816fded3790d065b"
   dependencies:
     ember-cli-babel "^5.1.5"
 
-ember-truth-helpers@1.3.0, ember-truth-helpers@^1.2.0:
+ember-truth-helpers@1.3.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/ember-truth-helpers/-/ember-truth-helpers-1.3.0.tgz#6ed9f83ce9a49f52bb416d55e227426339a64c60"
   dependencies:
@@ -4949,14 +4949,14 @@ js-tokens@^3.0.0:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-3.0.2.tgz#9866df395102130e38f7f996bceb65443209c25b"
 
-js-yaml@3.6.1:
+js-yaml@3.6.1, js-yaml@^3.5.1, js-yaml@^3.6.1:
   version "3.6.1"
   resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.6.1.tgz#6e5fe67d8b205ce4d22fad05b7781e8dadcc4b30"
   dependencies:
     argparse "^1.0.7"
     esprima "^2.6.0"
 
-js-yaml@3.8.4, js-yaml@3.x, js-yaml@^3.2.5, js-yaml@^3.2.7, js-yaml@^3.5.1, js-yaml@^3.6.1:
+js-yaml@3.8.4, js-yaml@3.x, js-yaml@^3.2.5, js-yaml@^3.2.7:
   version "3.8.4"
   resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.8.4.tgz#520b4564f86573ba96662af85a8cafa7b4b5a6f6"
   dependencies:

--- a/yarn.lock
+++ b/yarn.lock
@@ -31,6 +31,10 @@
     keen-tracking "1.1.3"
     langs "1.0.2"
 
+"@centerforopenscience/osf-style@1.4.2":
+  version "1.4.2"
+  resolved "https://registry.yarnpkg.com/@centerforopenscience/osf-style/-/osf-style-1.4.2.tgz#f5db9926a5cb41a6a5d31580e0f217799355ab39"
+
 JSONStream@^1.0.3:
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/JSONStream/-/JSONStream-1.3.1.tgz#707f761e01dae9e16f1bcf93703b78c70966579a"
@@ -3416,13 +3420,13 @@ ember-toastr@1.4.1:
   dependencies:
     ember-cli-babel "^5.0.0"
 
-ember-truth-helpers@1.2.0, ember-truth-helpers@^1.2.0:
+ember-truth-helpers@1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/ember-truth-helpers/-/ember-truth-helpers-1.2.0.tgz#e63cffeaa8211882ae61a958816fded3790d065b"
   dependencies:
     ember-cli-babel "^5.1.5"
 
-ember-truth-helpers@1.3.0:
+ember-truth-helpers@1.3.0, ember-truth-helpers@^1.2.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/ember-truth-helpers/-/ember-truth-helpers-1.3.0.tgz#6ed9f83ce9a49f52bb416d55e227426339a64c60"
   dependencies:
@@ -4945,14 +4949,14 @@ js-tokens@^3.0.0:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-3.0.2.tgz#9866df395102130e38f7f996bceb65443209c25b"
 
-js-yaml@3.6.1, js-yaml@3.x, js-yaml@^3.2.5, js-yaml@^3.2.7, js-yaml@^3.5.1, js-yaml@^3.6.1:
+js-yaml@3.6.1:
   version "3.6.1"
   resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.6.1.tgz#6e5fe67d8b205ce4d22fad05b7781e8dadcc4b30"
   dependencies:
     argparse "^1.0.7"
     esprima "^2.6.0"
 
-js-yaml@3.8.4:
+js-yaml@3.8.4, js-yaml@3.x, js-yaml@^3.2.5, js-yaml@^3.2.7, js-yaml@^3.5.1, js-yaml@^3.6.1:
   version "3.8.4"
   resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.8.4.tgz#520b4564f86573ba96662af85a8cafa7b4b5a6f6"
   dependencies:
@@ -6838,7 +6842,7 @@ repeating@^2.0.0:
   dependencies:
     is-finite "^1.0.0"
 
-request@2, request@2.79.0, request@^2.61.0, request@^2.74.0:
+request@2, request@2.79.0, request@^2.61.0, request@^2.74.0, request@^2.79.0:
   version "2.79.0"
   resolved "https://registry.yarnpkg.com/request/-/request-2.79.0.tgz#4dfe5bf6be8b8cdc37fcf93e04b65577722710de"
   dependencies:
@@ -6863,7 +6867,7 @@ request@2, request@2.79.0, request@^2.61.0, request@^2.74.0:
     tunnel-agent "~0.4.1"
     uuid "^3.0.0"
 
-request@^2.79.0, request@^2.81.0:
+request@^2.81.0:
   version "2.81.0"
   resolved "https://registry.yarnpkg.com/request/-/request-2.81.0.tgz#c6928946a0e06c5f8d6f8a9333469ffda46298a0"
   dependencies:


### PR DESCRIPTION
## Ticket

https://openscience.atlassian.net/browse/EOSF-736

## Purpose

Update to use the newest osf-style via node_modules instead of bower.

## Changes

Update ember-cli and remove some un-needed style imports.

## Side effects

Some unused imports were removed or updated.  Please check that preprints doesn't have any unexpected styles or behaviors.