### PR TITLE
use unescape instead of decodeURIComponent and get the sentryDSN from…

### DIFF
--- a/app/index.html
+++ b/app/index.html
@@ -31,7 +31,7 @@
     <script>
         (function() {
             var encodedConfig = document.head.querySelector("meta[name$='/config/environment']").content;
-            var config = JSON.parse(decodeURIComponent(encodedConfig));
+            var config = JSON.parse(unescape(encodedConfig));
             var assetSuffix = config.ASSET_SUFFIX ? '-' + config.ASSET_SUFFIX : '';
             var origin = window.location.origin;
             window.isProviderDomain = !~config.OSF.url.indexOf(origin);

--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -72,13 +72,19 @@ module.exports = function(defaults) {
                 enabled: useCdn,
                 content: `
                     <script src="https://cdn.ravenjs.com/3.5.1/ember/raven.min.js"></script>
-                    <script>Raven.config("${config.sentryDSN}", {}).install();</script>`.trim()
+                    <script>
+                        var encodedConfig = document.head.querySelector("meta[name$='/config/environment']").content;
+                        var config = JSON.parse(unescape(encodedConfig));
+                        Raven.config(config.sentryDSN, {}).install();
+                    </script>
+                `.trim()
             },
             cdn: {
                 enabled: useCdn,
                 content: `
                     <script src="//cdnjs.cloudflare.com/ajax/libs/jquery/2.2.4/jquery.min.js"></script>
-                    <script src="//cdnjs.cloudflare.com/ajax/libs/ember.js/2.7.1/ember.prod.js"></script>`.trim()
+                    <script src="//cdnjs.cloudflare.com/ajax/libs/ember.js/2.7.1/ember.prod.js"></script>
+                `.trim()
             },
         },
         postcssOptions: {


### PR DESCRIPTION
Sentry DSN from the ember config vs embedding it at build time. Also, use the same unescape function that ember uses to parse the config.